### PR TITLE
Add a per-repo post-publish-script option

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -65,6 +65,7 @@ pub struct RepoConfig {
     pub base_url: Option<String>,
     pub runtime_repo_url: Option<String>,
     pub subsets: HashMap<String, SubsetConfig>,
+    pub post_publish_script: Option<String>,
 }
 
 fn default_host() -> String {


### PR DESCRIPTION
If set, this will be run after a sucessful publish operation.
We want to use this in flathub to purge the caches on the cdn.