### PR TITLE
api: Set min-free-space-size=500MB on build repos

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -50,6 +50,7 @@ fn init_ostree_repo(repo_path: &path::PathBuf, parent_repo_path: &path::PathBuf,
 r#"[core]
 repo_version=1
 mode=archive-z2
+min-free-space-size=500MB
 {}parent={}"#,
                            match opt_collection_id {
                                Some(collection_id) => format!("collection-id={}.Build{}\n", collection_id, build_id),


### PR DESCRIPTION
I think as this is unset, the build repos are defaulting to the ostree default of 3% which is actually a remarkably large amount of space on a 1TB volume:
```
Apr 18 13:46:42 hub.flathub.org flat-manager[30875]: WARN 2019-04-18T13:46:42Z: actix_web::pipeline: Error occurred during request handling: WrongRepoState(ready): Build failed: InternalError: Command "flatpak" "build-commit-from" "--timestamp=NOW" "--no-update-summary" "--untrusted" "--force" "--disable-fsync" "--gpg-homedir=/srv/gpg/agent" "--gpg-sign=4184DD4D907A7CAE" "--src-repo=/srv/repo/builds/2314/upload" "--src-ref=c7223e23cdf60061c58a499d4c0fa8495d894cd56d42f28f780ba06cd209b83f" "/srv/repo/builds/2314" "screenshots/i386" exited unsuccesfully: error: min-free-space-percent '3%' would be exceeded
```