### PR TITLE
jobs: Add DeployCollectionID key to flatpakref

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -147,6 +147,8 @@ pub struct RepoConfig {
     pub suggested_repo_name: Option<String>,
     pub path: PathBuf,
     pub collection_id: Option<String>,
+    #[serde(default)]
+    pub deploy_collection_id: bool,
     pub gpg_key: Option<String>,
     #[serde(skip)]
     pub gpg_key_content: Option<String>,

--- a/src/jobs.rs
+++ b/src/jobs.rs
@@ -101,6 +101,15 @@ IsRuntime=false
 Url={}
 "#, app_id, branch, title, url);
 
+    /* We only want to deploy the collection ID if the flatpakref is being generated for the main
+     * repo not a build repo.
+     */
+    if let Some(collection_id) = &repoconfig.collection_id {
+        if repoconfig.deploy_collection_id && maybe_build_id == None {
+            contents.push_str(&format!("DeployCollectionID={}\n", collection_id));
+        }
+    };
+
     if maybe_build_id == None {
         if let Some(suggested_name) = &repoconfig.suggested_repo_name {
             contents.push_str(&format!("SuggestRemoteName={}\n", suggested_name));


### PR DESCRIPTION
In preparation for Flathub deploying collection IDs to users, add the
DeployCollectionID key to generated flatpakref files. Although only
Flatpak >= 1.0.6 will honor it, older versions will ignore it without
producing an error.

The addition of DeployCollectionID to the flatpakrepo file and
ostree.deploy-collection-id to the repo metadata will have to be made
manually.