### PR TITLE
Add various ostree helpers

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -62,7 +62,7 @@ min-free-space-size=500MB
 
 fn db_request<M: DbRequest> (state: &AppState,
                              msg: M) ->
-    Box<Future<Item = <M as DbRequest>::DbType, Error = ApiError>>
+    Box<dyn Future<Item = <M as DbRequest>::DbType, Error = ApiError>>
     where
     DbExecutor: actix::Handler<DbRequestWrapper<M>>
 {
@@ -543,7 +543,7 @@ fn start_save(
 fn save_file(
     field: multipart::Field<dev::Payload>,
     state: &Arc<UploadState>
-) -> Box<Future<Item = i64, Error = ApiError>> {
+) -> Box<dyn Future<Item = i64, Error = ApiError>> {
     let repo_subpath = match get_upload_subpath (&field, state) {
         Ok(subpath) => subpath,
         Err(e) => return Box::new(future::err(e)),
@@ -597,7 +597,7 @@ fn save_file(
 fn handle_multipart_item(
     item: multipart::MultipartItem<dev::Payload>,
     state: &Arc<UploadState>
-) -> Box<Stream<Item = i64, Error = ApiError>> {
+) -> Box<dyn Stream<Item = i64, Error = ApiError>> {
     match item {
         multipart::MultipartItem::Field(field) => {
             Box::new(save_file(field, state).into_stream())

--- a/src/bin/delta-generator-client.rs
+++ b/src/bin/delta-generator-client.rs
@@ -181,7 +181,7 @@ impl Actor for DeltaClient {
 
 fn pull_and_generate_delta_async(repo_path: &PathBuf,
                                  url: &String,
-                                 delta: &ostree::Delta) -> Box<Future<Item=(), Error=DeltaGenerationError>> {
+                                 delta: &ostree::Delta) -> Box<dyn Future<Item=(), Error=DeltaGenerationError>> {
     let url = url.clone();
     let repo_path2 = repo_path.clone();
     let delta_clone = delta.clone();
@@ -219,7 +219,7 @@ pub fn upload_delta(fs_pool: &FsPool,
                     token: &String,
                     repo: &String,
                     repo_path: &PathBuf,
-                    delta: &ostree::Delta) -> Box<Future<Item=(), Error=DeltaGenerationError>> {
+                    delta: &ostree::Delta) -> Box<dyn Future<Item=(), Error=DeltaGenerationError>> {
     let url = format!("{}/api/v1/delta/upload/{}", base_url, repo);
     let token = token.clone();
 

--- a/src/ostree.rs
+++ b/src/ostree.rs
@@ -170,7 +170,8 @@ impl<'a> SubVariant<'a> {
     }
 
     fn parse_as_string(&self) -> OstreeResult<String> {
-        if let Ok(str) = str::from_utf8(self.data) {
+        let without_nul = &self.data[0..self.data.len() - 1];
+        if let Ok(str) = str::from_utf8(without_nul) {
             Ok(str.to_string())
         } else {
             return Err(OstreeError::InvalidUtf8);

--- a/src/ostree.rs
+++ b/src/ostree.rs
@@ -248,7 +248,7 @@ pub fn get_commit (repo_path: &path::PathBuf, commit: &String) ->OstreeResult<Os
 
     let ostree_commit_fields = vec![
         // 0 - a{sv} - Metadata
-        VariantFieldInfo { size: VariantSize::Variable, alignment: 0 },
+        VariantFieldInfo { size: VariantSize::Variable, alignment: 8 },
         // 1 - ay - parent checksum (empty string for initial)
         VariantFieldInfo { size: VariantSize::Variable, alignment: 0 },
         // 2- a(say) - Related objects

--- a/src/ostree.rs
+++ b/src/ostree.rs
@@ -61,14 +61,26 @@ struct SubVariant<'a> {
     data: &'a [u8],
 }
 
-impl<'a> SubVariant<'a> {
-    fn new(data: &'a [u8]) -> SubVariant<'a> {
-        SubVariant {
-            offset: 0,
+#[derive(Debug)]
+struct Variant {
+    data: Vec<u8>,
+}
+
+impl Variant {
+    fn new(data: Vec<u8>) -> Variant {
+        Variant {
             data: data,
         }
     }
+    fn root<'a>(&'a self) -> SubVariant<'a> {
+        SubVariant {
+            offset: 0,
+            data: &self.data,
+        }
+    }
+}
 
+impl<'a> SubVariant<'a> {
     fn framing_size(&self) -> usize {
         let len = self.data.len() as u64;
         if len == 0 {
@@ -265,7 +277,8 @@ pub fn get_commit (repo_path: &path::PathBuf, commit: &String) ->OstreeResult<Os
         VariantFieldInfo { size: VariantSize::Variable, alignment: 0 },
     ];
 
-    let container = SubVariant::new(&contents);
+    let variant = Variant::new(contents);
+    let container = variant.root();
     let commit = container.parse_as_tuple(&ostree_commit_fields)?;
 
     Ok(OstreeCommit {

--- a/src/ostree.rs
+++ b/src/ostree.rs
@@ -57,7 +57,6 @@ struct VariantFieldInfo {
 
 #[derive(Debug)]
 struct SubVariant<'a> {
-    offset: usize,
     data: &'a [u8],
 }
 
@@ -74,7 +73,6 @@ impl Variant {
     }
     fn root<'a>(&'a self) -> SubVariant<'a> {
         SubVariant {
-            offset: 0,
             data: &self.data,
         }
     }
@@ -124,7 +122,7 @@ impl<'a> SubVariant<'a> {
         if alignment == 0 {
             cur
         } else {
-            let offset = cur + self.offset;
+            let offset = cur;
             cur + (alignment - (offset % alignment)) % alignment
         }
     }
@@ -134,7 +132,6 @@ impl<'a> SubVariant<'a> {
             return Err(OstreeError::InternalError(format!("Framing error: subset {}-{} out of bounds for {:?}", start, end, self)));
         }
         Ok( SubVariant {
-            offset: start + self.offset,
             data: &self.data[start..end],
         })
     }

--- a/src/ostree.rs
+++ b/src/ostree.rs
@@ -444,7 +444,7 @@ fn result_from_output(output: std::process::Output, command: &str) -> Result<(),
 pub fn pull_commit_async(n_retries: i32,
                          repo_path: PathBuf,
                          url: String,
-                         commit: String) -> Box<Future<Item=(), Error=OstreeError>> {
+                         commit: String) -> Box<dyn Future<Item=(), Error=OstreeError>> {
     Box::new(future::loop_fn(n_retries, move |count| {
         let mut cmd = Command::new("ostree");
         cmd
@@ -488,7 +488,7 @@ pub fn pull_commit_async(n_retries: i32,
 pub fn pull_delta_async(n_retries: i32,
                         repo_path: &PathBuf,
                         url: &String,
-                        delta: &Delta) -> Box<Future<Item=(), Error=OstreeError>> {
+                        delta: &Delta) -> Box<dyn Future<Item=(), Error=OstreeError>> {
     let url_clone = url.clone();
     let repo_path_clone = repo_path.clone();
     let to = delta.to.clone();
@@ -503,7 +503,7 @@ pub fn pull_delta_async(n_retries: i32,
 }
 
 pub fn generate_delta_async(repo_path: &PathBuf,
-                            delta: &Delta) -> Box<Future<Item=(), Error=OstreeError>> {
+                            delta: &Delta) -> Box<dyn Future<Item=(), Error=OstreeError>> {
     let mut cmd = Command::new("flatpak");
 
     cmd
@@ -537,7 +537,7 @@ pub fn generate_delta_async(repo_path: &PathBuf,
     )
 }
 
-pub fn prune_async(repo_path: &PathBuf) -> Box<Future<Item=(), Error=OstreeError>> {
+pub fn prune_async(repo_path: &PathBuf) -> Box<dyn Future<Item=(), Error=OstreeError>> {
     let mut cmd = Command::new("ostree");
 
     cmd

--- a/src/ostree.rs
+++ b/src/ostree.rs
@@ -447,13 +447,16 @@ pub fn pull_commit_async(n_retries: i32,
                          commit: String) -> Box<dyn Future<Item=(), Error=OstreeError>> {
     Box::new(future::loop_fn(n_retries, move |count| {
         let mut cmd = Command::new("ostree");
-        cmd
-            .before_exec (|| {
-                // Setsid in the child to avoid SIGINT on server killing
-                // child and breaking the graceful shutdown
-                unsafe { libc::setsid() };
-                Ok(())
-            });
+        unsafe {
+            cmd
+                .pre_exec (|| {
+                    // Setsid in the child to avoid SIGINT on server killing
+                    // child and breaking the graceful shutdown
+                    libc::setsid();
+                    Ok(())
+                });
+        }
+
         cmd
             .arg(&format!("--repo={}", &repo_path.to_str().unwrap()))
             .arg("pull")
@@ -506,13 +509,15 @@ pub fn generate_delta_async(repo_path: &PathBuf,
                             delta: &Delta) -> Box<dyn Future<Item=(), Error=OstreeError>> {
     let mut cmd = Command::new("flatpak");
 
-    cmd
-        .before_exec (|| {
-            // Setsid in the child to avoid SIGINT on server killing
-            // child and breaking the graceful shutdown
-            unsafe { libc::setsid() };
-            Ok(())
-        });
+    unsafe {
+        cmd
+            .pre_exec (|| {
+                // Setsid in the child to avoid SIGINT on server killing
+                // child and breaking the graceful shutdown
+                libc::setsid();
+                Ok(())
+            });
+    }
 
     cmd
         .arg("build-update-repo")
@@ -540,13 +545,15 @@ pub fn generate_delta_async(repo_path: &PathBuf,
 pub fn prune_async(repo_path: &PathBuf) -> Box<dyn Future<Item=(), Error=OstreeError>> {
     let mut cmd = Command::new("ostree");
 
-    cmd
-        .before_exec (|| {
-            // Setsid in the child to avoid SIGINT on server killing
-            // child and breaking the graceful shutdown
-            unsafe { libc::setsid() };
-            Ok(())
-        });
+    unsafe {
+        cmd
+            .pre_exec (|| {
+                // Setsid in the child to avoid SIGINT on server killing
+                // child and breaking the graceful shutdown
+                libc::setsid();
+                Ok(())
+            });
+    }
 
     cmd
         .arg("prune")

--- a/src/ostree.rs
+++ b/src/ostree.rs
@@ -317,7 +317,7 @@ impl<'a> SubVariant<'a> {
 
     fn parse_as_variable_width_array(&self, element_alignment: usize) -> OstreeResult<Vec<SubVariant<'a>>> {
         let t = self.type_string.as_bytes()[0] as char;
-        if (t != 'a') {
+        if t != 'a' {
             return Err(OstreeError::InternalError(format!("Not an array: {}", self.type_string)));
         }
 

--- a/src/ostree.rs
+++ b/src/ostree.rs
@@ -138,7 +138,7 @@ struct SubVariant<'a> {
 }
 
 #[derive(Debug)]
-struct Variant {
+pub struct Variant {
     type_string: String,
     data: Vec<u8>,
 }
@@ -171,6 +171,13 @@ impl Variant {
 }
 
 impl<'a> SubVariant<'a> {
+    fn copy(&self) -> Variant {
+        return Variant {
+            type_string: self.type_string.to_string(),
+            data: self.data.to_vec(),
+        }
+    }
+
     fn framing_size(&self) -> usize {
         let len = self.data.len() as u64;
         if len == 0 {


### PR DESCRIPTION
This supercharges the code in ostree for parsing gvariants. I want to use this in https://github.com/flatpak/flat-manager/pull/19 rather than linking to glib.