### PR TITLE
Support requiring tokens for some refs

### DIFF
--- a/flat-manager-client
+++ b/flat-manager-client
@@ -366,11 +366,15 @@ async def wait_for_job(session, job_url, token):
             sleep_time=60
         time.sleep(sleep_time)
 
-async def commit_build(session, build_url, eol, eol_rebase, wait, token):
+async def commit_build(session, build_url, eol, eol_rebase, token_type, wait, token):
     print("Committing build %s" % (build_url))
-    resp = await session.post(build_url + "/commit", headers={'Authorization': 'Bearer ' + token}, json= {
-        "endoflife": eol, "endoflife_rebase": eol_rebase
-    })
+    json = {
+        "endoflife": eol,
+        "endoflife_rebase": eol_rebase
+    }
+    if token_type != None:
+        json['token_type'] = token_type
+    resp = await session.post(build_url + "/commit", headers={'Authorization': 'Bearer ' + token}, json=json)
     async with resp:
         if resp.status != 200:
             raise ApiError(resp, await resp.text())
@@ -542,7 +546,7 @@ async def push_command(session, args):
 
     # Note, this always uses the full token, as the minimal one only has upload permissions
     if args.commit or args.publish:
-        commit_job = await commit_build(session, args.build_url, args.end_of_life, args.end_of_life_rebase, args.publish or args.wait, args.token)
+        commit_job = await commit_build(session, args.build_url, args.end_of_life, args.end_of_life_rebase, args.token_type, args.publish or args.wait, args.token)
 
     if args.publish:
         publish_job = await publish_build(session, args.build_url, args.wait or args.wait_update, args.token)
@@ -568,7 +572,7 @@ async def push_command(session, args):
     return data
 
 async def commit_command(session, args):
-    job = await commit_build(session, args.build_url, args.end_of_life, args.end_of_life_rebase, args.wait, args.token)
+    job = await commit_build(session, args.build_url, args.end_of_life, args.end_of_life_rebase, args.token_type, args.wait, args.token)
     return job
 
 async def publish_command(session, args):
@@ -646,6 +650,7 @@ if __name__ == '__main__':
                              help='Create minimal token for the upload')
     push_parser.add_argument('--end-of-life', help='Set end of life')
     push_parser.add_argument('--end-of-life-rebase', help='Set new ID which will supercede the current one')
+    push_parser.add_argument('--token-type', help='Set token type', type=int)
     push_parser.set_defaults(func=push_command)
 
     commit_parser = subparsers.add_parser('commit', help='Commit build')
@@ -653,6 +658,7 @@ if __name__ == '__main__':
                              help='wait for commit to finish')
     commit_parser.add_argument('--end-of-life', help='Set end of life')
     commit_parser.add_argument('--end-of-life-rebase', help='Set new ID which will supercede the current one')
+    commit_parser.add_argument('--token-type', help='Set token type', type=int)
     commit_parser.add_argument('build_url', help='remote build url')
     commit_parser.set_defaults(func=commit_command)
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -667,6 +667,7 @@ pub fn get_commit_job(
 pub struct CommitArgs {
     endoflife: Option<String>,
     endoflife_rebase: Option<String>,
+    token_type: Option<i32>,
 }
 
 pub fn commit(
@@ -689,6 +690,7 @@ pub fn commit(
                             id: build_id,
                             endoflife: args.endoflife.clone(),
                             endoflife_rebase: args.endoflife_rebase.clone(),
+                            token_type: args.token_type,
                         })
         })
         .and_then(move |job| {

--- a/src/api.rs
+++ b/src/api.rs
@@ -133,7 +133,7 @@ pub fn token_subset(
                 let new_claims = Claims {
                     sub: args.sub.clone(),
                     scope: args.scope.clone(),
-                    name: claims.name + "/" + &args.name,
+                    name: Some(claims.name.unwrap_or("".to_string()) + "/" + &args.name),
                     prefixes: { if let Some(ref prefixes) = args.prefixes { prefixes.clone() } else { claims.prefixes.clone() } },
                     repos: { if let Some(ref repos) = args.repos { repos.clone() } else { claims.repos.clone() } },
                     exp: new_exp,

--- a/src/app.rs
+++ b/src/app.rs
@@ -110,10 +110,14 @@ mod tests {
 pub struct Claims {
     pub sub: String, // "build", "build/N"
     pub scope: Vec<String>, // "build", "upload" "publish"
-    pub prefixes: Vec<String>, // [''] => all, ['org.foo'] => org.foo + org.foo.bar (but not org.foobar)
-    pub repos: Vec<String>, // list of repo names or a '' for match all
-    pub name: String, // for debug/logs only
     pub exp: i64,
+
+    // Below are optional, and not used for e.g. repo claims
+    #[serde(default)]
+    pub prefixes: Vec<String>, // [''] => all, ['org.foo'] => org.foo + org.foo.bar (but not org.foobar)
+    #[serde(default)]
+    pub repos: Vec<String>, // list of repo names or a '' for match all
+    pub name: Option<String>, // for debug/logs only
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/src/app.rs
+++ b/src/app.rs
@@ -113,10 +113,11 @@ mod tests {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Claims {
     pub sub: String, // "build", "build/N", or user id for repo tokens
-    pub scope: Vec<String>, // "build", "upload" "publish", or list of id prefixes for repo tokens
     pub exp: i64,
 
     // Below are optional, and not used for repo tokens
+    #[serde(default)]
+    pub scope: Vec<String>, // "build", "upload" "publish"
     #[serde(default)]
     pub prefixes: Vec<String>, // [''] => all, ['org.foo'] => org.foo + org.foo.bar (but not org.foobar)
     #[serde(default)]
@@ -381,7 +382,7 @@ fn verify_repo_token(req: &HttpRequest<AppState>, commit: ostree::OstreeCommit, 
     for commit_ref in commit_refs {
         let ref_parts: Vec<&str> = commit_ref.split('/').collect();
         if (ref_parts[0] == "app" || ref_parts[0] == "runtime") && ref_parts.len() > 2 {
-            result = req.has_token_scope_prefix(ref_parts[1]);
+            result = req.has_token_prefix(ref_parts[1]);
             if result.is_ok() {
                 break; // Early exit, we have a match
             }

--- a/src/app.rs
+++ b/src/app.rs
@@ -147,6 +147,10 @@ pub struct RepoConfig {
     pub name: String,
     pub suggested_repo_name: Option<String>,
     pub path: PathBuf,
+    #[serde(default)]
+    pub default_token_type: i32,
+    #[serde(default)]
+    pub require_auth_for_token_types: Vec<i32>,
     pub collection_id: Option<String>,
     #[serde(default)]
     pub deploy_collection_id: bool,

--- a/src/db.rs
+++ b/src/db.rs
@@ -308,6 +308,7 @@ pub struct StartCommitJob {
     pub id: i32,
     pub endoflife: Option<String>,
     pub endoflife_rebase: Option<String>,
+    pub token_type: Option<i32>,
 }
 
 impl DbRequest for StartCommitJob {
@@ -343,6 +344,7 @@ impl Handler<DbRequestWrapper<StartCommitJob>> for DbExecutor {
                         build: msg.0.id,
                         endoflife: msg.0.endoflife,
                         endoflife_rebase: msg.0.endoflife_rebase,
+                        token_type: msg.0.token_type,
                     }).to_string(),
                 })
                 .get_result::<Job>(conn)?;

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -192,7 +192,7 @@ impl ApiError {
             ApiError::NotEnoughPermissions(ref message) => json!({
                 "status": 403,
                 "error-type": "token-insufficient",
-                "message": format!("Not enough permissions: {})", message),
+                "message": format!("Not enough permissions: {}", message),
             }),
         }
     }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -67,6 +67,16 @@ impl From<OstreeError> for JobError {
     }
 }
 
+impl From<OstreeError> for ApiError {
+    fn from(e: OstreeError) -> Self {
+        match e {
+            _ => {
+                ApiError::InternalServerError(e.to_string())
+            }
+        }
+    }
+}
+
 impl From<DeltaGenerationError> for JobError {
     fn from(e: DeltaGenerationError) -> Self {
         match e {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -153,7 +153,7 @@ impl From<actix::MailboxError> for ApiError {
 }
 
 impl ApiError {
-    pub fn to_json(&self) -> String {
+    pub fn to_json(&self) -> serde_json::Value {
         match *self {
             ApiError::InternalServerError(ref _internal_message) => json!({
                 "status": 500,
@@ -195,7 +195,6 @@ impl ApiError {
                 "message": format!("Not enough permissions: {})", message),
             }),
         }
-        .to_string()
     }
 
     pub fn status_code(&self) -> StatusCode {

--- a/src/jobs.rs
+++ b/src/jobs.rs
@@ -341,6 +341,7 @@ struct CommitJobInstance {
     pub build_id: i32,
     pub endoflife: Option<String>,
     pub endoflife_rebase: Option<String>,
+    pub token_type: Option<i32>,
 }
 
 impl CommitJobInstance {
@@ -351,6 +352,7 @@ impl CommitJobInstance {
                 build_id: commit_job.build,
                 endoflife: commit_job.endoflife,
                 endoflife_rebase: commit_job.endoflife_rebase,
+                token_type: commit_job.token_type,
             })
         } else {
             InvalidJobInstance::new(job, JobError::new("Can't parse commit job"))
@@ -405,6 +407,11 @@ impl CommitJobInstance {
                     .arg(&endoflife_rebase_arg);
             };
 
+            if let Some(token_type) = &self.token_type {
+                cmd
+                    .arg(format!("--token-type={}", token_type));
+            };
+
             cmd
                 .arg(&src_repo_arg)
                 .arg(&src_ref_arg)
@@ -451,8 +458,8 @@ impl JobInstance for CommitJobInstance {
     }
 
     fn handle_job (&mut self, executor: &JobExecutor, conn: &PgConnection) -> JobResult<serde_json::Value> {
-        info!("#{}: Handling Job Commit: build: {}, end-of-life: {}, eol-rebase: {}",
-              &self.job_id, &self.build_id, self.endoflife.as_ref().unwrap_or(&"".to_string()), self.endoflife_rebase.as_ref().unwrap_or(&"".to_string()));
+        info!("#{}: Handling Job Commit: build: {}, end-of-life: {}, eol-rebase: {}, token-type: {:?}",
+              &self.job_id, &self.build_id, self.endoflife.as_ref().unwrap_or(&"".to_string()), self.endoflife_rebase.as_ref().unwrap_or(&"".to_string()), self.token_type);
 
         let config = &executor.config;
 

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -49,7 +49,11 @@ impl Logger {
             let rt = ((time::now() - entry_time.0).num_nanoseconds().unwrap_or(0) as f64) / 1_000_000_000.0;
 
             let token_name = if let Some(ref claims) = req.get_claims() {
-                claims.name.clone()
+                if let Some(ref name) = claims.name {
+                    name.clone()
+                } else {
+                    "-".to_string()
+                }
             } else {
                 "-".to_string()
             };

--- a/src/models.rs
+++ b/src/models.rs
@@ -231,6 +231,7 @@ pub struct CommitJob {
     pub build: i32,
     pub endoflife: Option<String>,
     pub endoflife_rebase: Option<String>,
+    pub token_type: Option<i32>,
 }
 
 

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -13,7 +13,6 @@ pub trait ClaimsValidator {
     fn has_token_claims(&self, required_sub: &str, required_scope: &str) -> Result<(), ApiError>;
     fn has_token_prefix(&self, id: &str) -> Result<(), ApiError>;
     fn has_token_repo(&self, repo: &str) -> Result<(), ApiError>;
-    fn has_token_scope_prefix(&self, id: &str) -> Result<(), ApiError>;
 }
 
 pub fn sub_has_prefix(required_sub: &str, claimed_sub: &str) -> bool {
@@ -96,18 +95,6 @@ impl<S> ClaimsValidator for HttpRequest<S> {
         self.validate_claims(|claims| {
             if !id_matches_one_prefix(id, &claims.prefixes) {
                 return Err(ApiError::NotEnoughPermissions(format!("Id {} not matching prefix in token", id)));
-            }
-            Ok(())
-        })
-    }
-
-    /* This is an app id prefix match, just like has_token_prefix, but it looks at the
-     * scope key instead of prefixes, and is used for repo token checks rather than API calls.
-     */
-    fn has_token_scope_prefix(&self, id: &str) -> Result<(), ApiError> {
-        self.validate_claims(|claims| {
-            if !id_matches_one_prefix(id, &claims.scope) {
-                return Err(ApiError::NotEnoughPermissions(format!("Id {} not matching scope in token", id)));
             }
             Ok(())
         })

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -13,6 +13,7 @@ pub trait ClaimsValidator {
     fn has_token_claims(&self, required_sub: &str, required_scope: &str) -> Result<(), ApiError>;
     fn has_token_prefix(&self, id: &str) -> Result<(), ApiError>;
     fn has_token_repo(&self, repo: &str) -> Result<(), ApiError>;
+    fn has_token_scope_prefix(&self, id: &str) -> Result<(), ApiError>;
 }
 
 pub fn sub_has_prefix(required_sub: &str, claimed_sub: &str) -> bool {
@@ -95,6 +96,18 @@ impl<S> ClaimsValidator for HttpRequest<S> {
         self.validate_claims(|claims| {
             if !id_matches_one_prefix(id, &claims.prefixes) {
                 return Err(ApiError::NotEnoughPermissions(format!("Id {} not matching prefix in token", id)));
+            }
+            Ok(())
+        })
+    }
+
+    /* This is an app id prefix match, just like has_token_prefix, but it looks at the
+     * scope key instead of prefixes, and is used for repo token checks rather than API calls.
+     */
+    fn has_token_scope_prefix(&self, id: &str) -> Result<(), ApiError> {
+        self.validate_claims(|claims| {
+            if !id_matches_one_prefix(id, &claims.scope) {
+                return Err(ApiError::NotEnoughPermissions(format!("Id {} not matching scope in token", id)));
             }
             Ok(())
         })


### PR DESCRIPTION
This is an alternative version of https://github.com/flatpak/flat-manager/pull/19
and builds on the flatpak work here: https://github.com/flatpak/flatpak/pull/3167

This assumes that some commits in the repo can have the xa.token-type set to a value != 0, and if so the flatpak authentication machinery will call into the authenticator api and can (optionally) return a bearer token that flatpak will pass when downloading the ref. The idea is that the authenticator can handle tokens differently. Some may be optional like donation requests, and trigger some nagging, but not actually send a token, whereas others do cause a token to be sent.

On the server side you can set the new `require-auth-for-token-types` option for the repo to a list of which token types require authentication. Additionally there is a `default-token-type` option that can easily make all refs private.

Whenever a commit object or a delta superblock is read we extract the token-type from it, and if
it matches the required types we look at the token and ensure that the ref (which we also get from the commit object) matches the set of id prefixes in the token.