### PR TITLE
repo: Allow /s in repo names

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -433,8 +433,6 @@ fn handle_repo(config: Data<Config>,
     }
 
     if let Some(commit) = get_commit_for_file (&path) {
-        let repo = req.match_info().query("repo");
-        let repoconfig = config.get_repoconfig(&repo)?;
         verify_repo_token(&req, commit, repoconfig, &path)?;
     }
 


### PR DESCRIPTION
At Endless we have repos organized into staging subdirectories, but the
repo resource was only allowing a single path element. This changes the
parameter to a single glob and then walks backwards to find a repo name
that matches a path prefix.