### PR TITLE
Add Jenkinsfile for building on Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,36 @@
+pipeline {
+    agent {
+        docker {
+            image 'rust:slim'
+            // Need to run as root to install packages
+            args '-u 0:0'
+        }
+    }
+    stages {
+        stage('Dependencies') {
+            steps {
+                sh 'apt-get update'
+                sh 'apt-get -y install libpq-dev'
+                sh 'cargo fetch'
+            }
+        }
+        stage('Build') {
+            steps {
+                sh 'cargo build --release'
+            }
+        }
+        stage('Test') {
+            steps {
+                sh 'cargo test --release'
+            }
+        }
+        stage('Publish') {
+            steps {
+                archiveArtifacts 'flat-manager-client'
+                archiveArtifacts 'target/release/delta-generator-client'
+                archiveArtifacts 'target/release/flat-manager'
+                archiveArtifacts 'target/release/gentoken'
+            }
+        }
+    }
+}


### PR DESCRIPTION
This simply uses a rust image from dockerhub.io and runs `cargo build
--release` and `cargo test --release`. The built binaries and the client
are archived for later retrieval.

I know you don't use Jenkins, but we do at Endless and having the `Jenkinsfile` in the repo is really helpful. The pipeline has nothing Endless specific in it. Without having it here I have to maintain a flat-manager fork in endlessm. I can move it to a separate directory if that's preferred.