### PR TITLE
ostree: Always include from-scratch deltas in wanted deltas

### DIFF
--- a/src/ostree.rs
+++ b/src/ostree.rs
@@ -778,6 +778,7 @@ pub fn calc_deltas_for_ref (repo_path: &path::PathBuf, ref_name: &str, depth: u3
         return res;
     }
     let to_commit = to_commit_res.unwrap();
+    res.push(Delta::new(None, &to_commit));
 
     let mut from_commit : Option<String> = None;
     for _i in 0..depth {


### PR DESCRIPTION
If from-scratch delta is not generated and uploaded by the client,
flat-manager never generates it on its own. As it's potentially
common oversight, from-scratch deltas should always be generated
on flat-manager end.

This means the only way to disable deltas completely is to set depth
to -1.