### PR TITLE
jobs: Extract appstream before running post-publish script

### DIFF
--- a/src/jobs.rs
+++ b/src/jobs.rs
@@ -945,11 +945,11 @@ impl JobInstance for UpdateRepoJobInstance {
         self.generate_deltas(&missing_deltas, repoconfig, conn)?;
         self.retire_deltas(&unwanted_deltas, repoconfig, conn)?;
 
+        self.extract_appstream(repoconfig, conn)?;
+
         self.update_summary(config, repoconfig, conn)?;
 
         self.run_post_publish(repoconfig, conn)?;
-
-        self.extract_appstream(repoconfig, conn)?;
 
         Ok(json!({ }))
     }


### PR DESCRIPTION
Post-publish is expected to be the final step of build processing.