### PR TITLE
Allow passing the manager URL with a base path

### DIFF
--- a/flat-manager-client
+++ b/flat-manager-client
@@ -427,7 +427,7 @@ async def purge_build(session, build_url, token):
         return await resp.json()
 
 async def create_token(session, manager_url, token, name, subject, scope, duration):
-    token_url = urljoin(manager_url, "/api/v1/token_subset")
+    token_url = urljoin(manager_url, "api/v1/token_subset")
     resp = await session.post(token_url, headers={'Authorization': 'Bearer ' + token}, json = {
         "name": name,
         "sub": subject,
@@ -443,7 +443,7 @@ def get_object_multipart(repo_path, object):
     return AsyncNamedFilePart(repo_path + "/objects/" + object[:2] + "/" + object[2:], filename=object)
 
 async def create_command(session, args):
-    build_url = urljoin(args.manager_url, "/api/v1/build")
+    build_url = urljoin(args.manager_url, "api/v1/build")
     resp = await session.post(build_url, headers={'Authorization': 'Bearer ' + args.token}, json={
         "repo": args.repo
     })


### PR DESCRIPTION
For manager url with a base directory, like https://site/some/path,
calling urljoin with absolute path would replace existing path in
URL. Change the API url with relative path to allow pass a manager
URL with a base path.