### PR TITLE
Add support for rebasing EOL extensions

### DIFF
--- a/src/jobs.rs
+++ b/src/jobs.rs
@@ -361,6 +361,12 @@ impl CommitJobInstance {
         }
     }
 
+    fn get_main_build_ref_name (build_refs: &Vec<models::BuildRef>) -> &str {
+        return &build_refs.iter().min_by_key(|build_ref| {
+            build_ref.ref_name.split('/').nth(1).unwrap().len()
+        }).unwrap().ref_name
+    }
+
     fn do_commit_build_refs (&self,
                              build_refs: &Vec<models::BuildRef>,
                              config: &Config,
@@ -375,11 +381,8 @@ impl CommitJobInstance {
         let mut commits = HashMap::new();
 
         let endoflife_rebase_arg = if let Some(endoflife_rebase) = &self.endoflife_rebase {
-            if let Some(app_ref) = build_refs.iter().filter(|app_ref| app_ref.ref_name.starts_with("app/")).nth(0) {
-                Some(format!("--end-of-life-rebase={}={}", app_ref.ref_name.split('/').nth(1).unwrap(), endoflife_rebase))
-            } else {
-                None
-            }
+            let old_prefix = CommitJobInstance::get_main_build_ref_name(build_refs).split('/').nth(1).unwrap();
+            Some(format!("--end-of-life-rebase={}={}", old_prefix, endoflife_rebase))
         } else {
             None
         };

--- a/src/jobs.rs
+++ b/src/jobs.rs
@@ -270,6 +270,8 @@ fn job_log_and_error(job_id: i32, conn: &PgConnection, output: &str) {
 
 fn do_command(mut cmd: Command) -> JobResult<()>
 {
+    info!("Running command: {:?}", &cmd);
+
     let output =
         unsafe {
             cmd


### PR DESCRIPTION
From the main commit message:
```
jobs: Consider every build ref when determining the EOL prefix
    
We assume that:
*  There is always at least one build ref being committed.
*  Committed ref names always include a ref type followed by a "/"
   character. For example, "app/" or "runtime/".
*  The main ref isn't necessarily an "app/" ref. For example, in the
   case of extension-only repos, the main ref is a "runtime/" ref.
*  The main ref being committed has the shortest ref name when
   removing its ref type. For example:
   *  When the committed ref names are "app/org.app.App" and
      "runtime/org.app.App.Plugin", the main ref is "app/org.app.App".
   *  When the committed ref names are "runtime/org.app.App.Plugin"
      and "runtime/org.app.App.Plugin.Debug", the main ref is
      "runtime/org.app.App.Plugin".
*  The main ref with its ref type removed should be considered to be
    he old prefix for the purpose of EOL rebasing.
    
This should allow rebasing EOL extensions in addition to apps.
```

Note that the assumptions above are based on my impression, not necessarily all correct. Please review thoroughly.