### PR TITLE
Return HTTP 401 when token is missing

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -117,6 +117,9 @@ pub enum ApiError {
 
     #[fail(display = "NotEnoughPermissions")]
     NotEnoughPermissions(String),
+
+    #[fail(display = "TokenRequired")]
+    TokenRequired,
 }
 
 impl From<DieselError> for ApiError {
@@ -182,6 +185,11 @@ impl ApiError {
                 "error-type": "token-insufficient",
                 "message": format!("Not enough permissions: {}", message),
             }),
+            ApiError::TokenRequired => json!({
+                "status": 401,
+                "error-type": "token-required",
+                "message": "Token required"
+            }),
         }
     }
 
@@ -196,6 +204,7 @@ impl ApiError {
             ApiError::WrongPublishedState(_, _, _) => StatusCode::BAD_REQUEST,
             ApiError::InvalidToken(_) => StatusCode::UNAUTHORIZED,
             ApiError::NotEnoughPermissions(ref _message) => StatusCode::FORBIDDEN,
+            ApiError::TokenRequired => StatusCode::UNAUTHORIZED,
         }
     }
 }

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -74,9 +74,7 @@ impl ClaimsValidator for HttpRequest {
         if let Some(claims) = self.extensions().get::<Claims>() {
             func(claims)
         } else {
-            Err(ApiError::NotEnoughPermissions(
-                "No token specified".to_string(),
-            ))
+            Err(ApiError::TokenRequired)
         }
     }
 


### PR DESCRIPTION
When the repository returns an HTTP 401 error, flatpak is supposed to request a token (if it hasn't already) using the authenticator. However, we currently return a 403, which causes the transaction to fail instead.

I'm marking this as a draft because I haven't been able to fully test it, due to https://github.com/flatpak/flatpak/issues/4862.