### PR TITLE
Add end-to-end test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,13 +39,14 @@ jobs:
 
      - name: Start containers
        working-directory: ./tests
-       run: docker-compose up -d
+       run: docker compose up -d
 
      - name: Wait for the containers to finish loading
        run: sleep 10
 
      - name: Run test
-       run: docker exec flat-manager ./tests/run-test.py
+       working-directory: ./tests
+       run: docker compose exec flat-manager ./tests/run-test.py
 
   fmt:
     name: Rustfmt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,22 @@ jobs:
         with:
           command: test
 
+  end-to-end:
+    name: End-to-end upload test
+    runs-on: ubuntu-latest
+    steps:
+     - uses: actions/checkout@v2
+
+     - name: Start containers
+       working-directory: ./tests
+       run: docker-compose up -d
+
+     - name: Wait for the containers to finish loading
+       run: sleep 10
+
+     - name: Run test
+       run: docker exec flat-manager ./tests/run-test.py
+
   fmt:
     name: Rustfmt
     runs-on: ubuntu-latest

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:latest
+FROM rust:1.61-bullseye
 
 # Install run-tests.py's dependencies
 RUN apt-get update

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,0 +1,29 @@
+FROM rust:latest
+
+# Install run-tests.py's dependencies
+RUN apt-get update
+RUN apt-get install -y flatpak flatpak-builder python3-pip python3-gi libostree-dev
+RUN flatpak remote-add flathub https://flathub.org/repo/flathub.flatpakrepo
+RUN flatpak install -y flathub org.freedesktop.Platform//21.08 org.freedesktop.Sdk//21.08
+RUN pip install asyncio aiohttp tenacity pygobject
+
+# Use the test config.json and configure it with a GPG key
+COPY ./tests/config.json ./test-config.json
+COPY ./tests/gen-key.sh ./gen-key.sh
+RUN ./gen-key.sh
+
+# Initialize the OSTree repo
+RUN ostree --repo=repo init --mode=archive-z2
+RUN mkdir build-repo
+
+# Copy the files
+COPY ./ ./
+
+# Make sure our test config.json is used, not one that was in the source directory
+RUN cp --force ./test-config.json ./config.json
+
+# Build flat-manager
+RUN cargo build
+
+# Wait 5 seconds for the database to start, then run flat-manager
+CMD ["sh", "-c", "sleep 5 ; ./target/debug/flat-manager"]

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,4 @@
+# flat-manager CI
+
+This test suite uses docker-compose to bring up a real flat-manager instance, running with a real database, to run
+tests against.

--- a/tests/config.json
+++ b/tests/config.json
@@ -1,0 +1,30 @@
+{
+    "repos": {
+        "stable": {
+            "path": "repo",
+            "collection-id": "org.test.Stable",
+            "suggested-repo-name": "flat-manager-test",
+            "runtime-repo-url": "https://dl.flathub.org/repo/flathub.flatpakrepo",
+            "gpg-key": "@GPG_KEY@",
+            "base-url": null,
+            "subsets": {
+                "all": {
+                    "collection-id": "org.test.Stable",
+                    "base-url": null
+                },
+                "free": {
+                    "collection-id": "org.test.Stable.test",
+                    "base-url": null
+                }
+            }
+        }
+    },
+    "port": 8080,
+    "delay-update-secs": 3,
+    "database-url": "postgres://postgres:postgres@db/test_db",
+    "build-repo-base": "build-repo",
+    "build-gpg-key": null,
+    "gpg-homedir": null,
+    "secret": "c2VjcmV0Cg==",
+    "repo-secret": "c2VjcmV0Cg=="
+}

--- a/tests/config.json
+++ b/tests/config.json
@@ -25,6 +25,6 @@
     "build-repo-base": "build-repo",
     "build-gpg-key": null,
     "gpg-homedir": null,
-    "secret": "c2VjcmV0Cg==",
-    "repo-secret": "c2VjcmV0Cg=="
+    "secret": "c2VjcmV0",
+    "repo-secret": "c2VjcmV0"
 }

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -1,0 +1,22 @@
+version: "3"
+
+services:
+  flat-manager:
+    privileged: true # needed for flatpak-builder to work
+    container_name: flat-manager
+    build:
+      dockerfile: tests/Dockerfile
+      context: ..
+    ports:
+      - "8080:8080"
+    depends_on:
+      - db
+
+  db:
+    image: docker.io/library/postgres:12
+    ports:
+      - "5432:5432"
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+      - POSTGRES_DB=test_db

--- a/tests/gen-key.sh
+++ b/tests/gen-key.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+# Generate a GPG key
+gpg --quick-gen-key --batch --yes --passphrase="" "flat-manager CI"
+
+# Find the key
+KEY=$(gpg --list-signatures --with-colons | grep "sig" | grep "flat-manager CI" | head -n 1 | awk -F":" '{print $5}')
+
+# Export the key so we can import it into flatpak
+gpg --export --armor > key.gpg
+
+# Set the key in the config file
+sed --in-place "s/@GPG_KEY@/$KEY/g" test-config.json

--- a/tests/hello.sh
+++ b/tests/hello.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+echo "Hello, world!"

--- a/tests/org.flatpak.FlatManagerCI.metainfo.xml
+++ b/tests/org.flatpak.FlatManagerCI.metainfo.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>org.flatpak.FlatManagerCI</id>
+  <name>flat-manager CI</name>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>CC-BY-4.0</project_license>
+  <url type="homepage">https://flatpak.org</url>
+  <summary>Test app for flat-manager's CI</summary>
+  <description><p>Test app for flat-manager's CI</p></description>
+  <screenshots>
+    <screenshot type="default">
+      <image type="source" width="800" height="600">https://placekitten.com/800/600</image>
+    </screenshot>
+  </screenshots>
+  <releases>
+    <release timestamp="2022-03-01" version="0.0.1"/>
+  </releases>
+  <content_rating></content_rating>
+</component>

--- a/tests/org.flatpak.FlatManagerCI.yml
+++ b/tests/org.flatpak.FlatManagerCI.yml
@@ -1,0 +1,16 @@
+app-id: org.flatpak.FlatManagerCI
+runtime: org.freedesktop.Platform
+runtime-version: '21.08'
+sdk: org.freedesktop.Sdk
+command: hello.sh
+modules:
+  - name: hello
+    buildsystem: simple
+    build-commands:
+      - install -D hello.sh /app/bin/hello.sh
+      - install -D org.flatpak.FlatManagerCI.metainfo.xml /app/share/metainfo/org.flatpak.FlatManagerCI.metainfo.xml
+    sources:
+      - type: file
+        path: hello.sh
+      - type: file
+        path: org.flatpak.FlatManagerCI.metainfo.xml

--- a/tests/run-test.py
+++ b/tests/run-test.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+
+import os, subprocess, sys, time
+from subprocess import PIPE
+
+def sleep(seconds):
+    print(f"Waiting {seconds} seconds")
+    time.sleep(seconds)
+
+def exec(cmd):
+    print("Executing", cmd)
+
+    p = subprocess.run(cmd, stdout=PIPE, stderr=sys.stderr)
+
+    if p.returncode != 0:
+        raise AssertionError(f"Command `{cmd}` failed with exit code {p.returncode}")
+
+    return p.stdout.decode().strip()
+
+REPO_DIR = "_repo"
+
+# Build the flatpak app
+exec(["flatpak-builder", "--force-clean", "--repo", REPO_DIR, "_flatpak", "tests/org.flatpak.FlatManagerCI.yml"])
+
+# Generate a flat-manager token
+os.environ["REPO_TOKEN"] =  exec(["cargo", "run", "--bin=gentoken", "--", "--secret=secret", "--repo=stable"])
+
+# Create a new build and save the repo URL
+build_repo = exec(["./flat-manager-client", "create", "http://127.0.0.1:8080", "stable"])
+
+# Push to the upload repo
+exec(["./flat-manager-client", "push", build_repo, REPO_DIR])
+
+# Commit to the build repo
+exec(["./flat-manager-client", "commit", build_repo])
+
+# Wait for that job to finish
+sleep(10)
+
+# Publish to the main repo
+exec(["./flat-manager-client", "publish", build_repo])
+
+# Wait for the repository to be updated
+sleep(15)
+
+# Make sure the app installs successfully
+exec(["flatpak", "remote-add", "flat-manager", "http://127.0.0.1:8080/repo/stable", "--gpg-import=key.gpg"])
+exec(["flatpak", "install", "-y", "flat-manager", "org.flatpak.FlatManagerCI"])


### PR DESCRIPTION
Add a test that runs flat-manager and postrges using docker-compose, and then builds, uploads, and downloads a trivial app. The test takes about 10 minutes.