### PR TITLE
Fix JSON error messages

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -213,4 +213,8 @@ impl ResponseError for ApiError {
         }
         HttpResponse::build(self.status_code()).json(self.to_json())
     }
+
+    fn render_response(&self) -> HttpResponse {
+        self.error_response()
+    }
 }


### PR DESCRIPTION
The render_response implementation was missing, so it defaulted to a plain text error message.