### PR TITLE
ci: Run end-to-end test in Fedora

### DIFF
--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,11 +1,10 @@
-FROM rust:1.61-bullseye
+FROM fedora:36
 
-# Install run-tests.py's dependencies
-RUN apt-get update
-RUN apt-get install -y flatpak flatpak-builder python3-pip python3-gi libostree-dev
+# Install Rust, Cargo, and run-tests.py's dependencies
+RUN dnf install -y rust cargo flatpak flatpak-builder python3-pip python3-gobject ostree-devel libpq-devel
 RUN flatpak remote-add flathub https://flathub.org/repo/flathub.flatpakrepo
-RUN flatpak install -y flathub org.freedesktop.Platform//21.08 org.freedesktop.Sdk//21.08
-RUN pip install asyncio aiohttp tenacity pygobject
+RUN flatpak install --noninteractive flathub org.freedesktop.Platform//21.08 org.freedesktop.Sdk//21.08
+RUN pip install asyncio aiohttp tenacity
 
 # Use the test config.json and configure it with a GPG key
 COPY ./tests/config.json ./test-config.json


### PR DESCRIPTION
The Debian-based image has an old version of libostree that makes everything more difficult when rewriting commits.