### PR TITLE
Fix deprecation warning and use asyncio.run

### DIFF
--- a/flat-manager-client
+++ b/flat-manager-client
@@ -717,8 +717,7 @@ if __name__ == '__main__':
     res = 1
     output = None
     try:
-        loop = asyncio.get_event_loop()
-        result = loop.run_until_complete(run_with_session(args))
+        result = asyncio.run(run_with_session(args))
 
         output = {
             "command": args.subparser_name,


### PR DESCRIPTION
This bumps requirement to Python 3.7