### PR TITLE
Add optional app ID to builds

### DIFF
--- a/flat-manager-client
+++ b/flat-manager-client
@@ -444,9 +444,12 @@ def get_object_multipart(repo_path, object):
 
 async def create_command(session, args):
     build_url = urljoin(args.manager_url, "api/v1/build")
-    resp = await session.post(build_url, headers={'Authorization': 'Bearer ' + args.token}, json={
+    json = {
         "repo": args.repo
-    })
+    }
+    if args.app_id is not None:
+        json["app_id"] = args.app_id
+    resp = await session.post(build_url, headers={'Authorization': 'Bearer ' + args.token}, json=json)
     async with resp:
         if resp.status != 200:
             raise ApiError(resp, await resp.text())
@@ -630,6 +633,7 @@ if __name__ == '__main__':
     create_parser = subparsers.add_parser('create', help='Create new build')
     create_parser.add_argument('manager_url', help='remote repo manager url')
     create_parser.add_argument('repo', help='repo name')
+    create_parser.add_argument('app_id', nargs='?', help='app ID')
     create_parser.set_defaults(func=create_command)
 
     push_parser = subparsers.add_parser('push', help='Push to repo manager')

--- a/flat-manager-client
+++ b/flat-manager-client
@@ -55,7 +55,7 @@ class ApiError(Exception):
         self.status = response.status
 
         try:
-            self.body = json.loads(response);
+            self.body = json.loads(body)
         except:
             self.body = {"status": self.status, "error-type": "no-error", "message": "No json error details from server"}
 

--- a/flat-manager-client
+++ b/flat-manager-client
@@ -449,6 +449,8 @@ async def create_command(session, args):
     }
     if args.app_id is not None:
         json["app-id"] = args.app_id
+    if args.public_download is not None:
+        json["public-download"] = args.public_download
     resp = await session.post(build_url, headers={'Authorization': 'Bearer ' + args.token}, json=json)
     async with resp:
         if resp.status != 200:
@@ -634,6 +636,8 @@ if __name__ == '__main__':
     create_parser.add_argument('manager_url', help='remote repo manager url')
     create_parser.add_argument('repo', help='repo name')
     create_parser.add_argument('app_id', nargs='?', help='app ID')
+    create_parser.add_argument('--public_download', action='store_true', default=None, help='allow public read access to the build repo')
+    create_parser.add_argument('--no_public_download', action='store_false', dest='public_download', default=None, help='allow public read access to the build repo')
     create_parser.set_defaults(func=create_command)
 
     push_parser = subparsers.add_parser('push', help='Push to repo manager')

--- a/flat-manager-client
+++ b/flat-manager-client
@@ -448,7 +448,7 @@ async def create_command(session, args):
         "repo": args.repo
     }
     if args.app_id is not None:
-        json["app_id"] = args.app_id
+        json["app-id"] = args.app_id
     resp = await session.post(build_url, headers={'Authorization': 'Bearer ' + args.token}, json=json)
     async with resp:
         if resp.status != 200:

--- a/migrations/2022-08-05-212616_add_build_app_id/down.sql
+++ b/migrations/2022-08-05-212616_add_build_app_id/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE builds DROP COLUMN app_id;

--- a/migrations/2022-08-05-212616_add_build_app_id/up.sql
+++ b/migrations/2022-08-05-212616_add_build_app_id/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE builds ADD app_id TEXT;

--- a/migrations/2022-09-06-002415_add_build_public_download/down.sql
+++ b/migrations/2022-09-06-002415_add_build_public_download/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE builds DROP COLUMN public_download;

--- a/migrations/2022-09-06-002415_add_build_public_download/up.sql
+++ b/migrations/2022-09-06-002415_add_build_public_download/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE builds ADD public_download BOOLEAN DEFAULT TRUE NOT NULL;

--- a/src/api.rs
+++ b/src/api.rs
@@ -26,7 +26,7 @@ use std::rc::Rc;
 use std::sync::Arc;
 use tempfile::NamedTempFile;
 
-use crate::app::{Claims, Config, ClaimsScope};
+use crate::app::{Claims, ClaimsScope, Config};
 use crate::db::*;
 use crate::deltas::{DeltaGenerator, RemoteWorker};
 use crate::errors::ApiError;

--- a/src/api.rs
+++ b/src/api.rs
@@ -217,6 +217,7 @@ async fn get_job_async(
 #[derive(Debug, Serialize, Deserialize)]
 pub struct CreateBuildArgs {
     repo: String,
+    app_id: Option<String>,
 }
 
 pub fn create_build(
@@ -240,11 +241,16 @@ async fn create_build_async(
     req.has_token_claims("build", ClaimsScope::Build)?;
     req.has_token_repo(&repo1)?;
 
+    if let Some(app_id) = &args.app_id {
+        req.has_token_prefix(app_id)?;
+    }
+
     let repoconfig = config.get_repoconfig(&repo2).map(|rc| rc.clone())?; // Ensure the repo exists
 
     let build = db
         .new_build(NewBuild {
             repo: args.repo.clone(),
+            app_id: args.app_id.clone(),
         })
         .await?;
     let build_repo_path = config.build_repo_base.join(build.id.to_string());

--- a/src/api.rs
+++ b/src/api.rs
@@ -492,7 +492,8 @@ async fn add_extra_ids_async(
 }
 
 fn is_all_lower_hexdigits(s: &str) -> bool {
-    !s.contains(|c: char| !c.is_digit(16) || c.is_uppercase())
+    s.chars()
+        .all(|c: char| c.is_ascii_hexdigit() && !c.is_uppercase())
 }
 
 fn filename_parse_object(filename: &str) -> Option<path::PathBuf> {
@@ -518,7 +519,7 @@ fn filename_parse_object(filename: &str) -> Option<path::PathBuf> {
 }
 
 fn is_all_digits(s: &str) -> bool {
-    !s.contains(|c: char| !c.is_digit(10))
+    !s.contains(|c: char| !c.is_ascii_digit())
 }
 
 /* Delta part filenames with no slashes, ending with .{part}.delta.
@@ -965,4 +966,16 @@ pub fn ws_delta(
         &req,
         stream,
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_all_lower_hexdigits() {
+        assert!(is_all_lower_hexdigits("0123456789abcdef"));
+        assert!(!is_all_lower_hexdigits("0123456789Abcdef"));
+        assert!(!is_all_lower_hexdigits("?"));
+    }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -10,6 +10,7 @@ use actix_web::{self, http, middleware, web, App, HttpRequest, HttpResponse, Htt
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::ffi::OsStr;
+use std::fmt::Display;
 use std::io;
 use std::path::Path;
 use std::path::PathBuf;
@@ -139,6 +140,24 @@ mod tests {
     }
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ClaimsScope {
+    Jobs,
+    Build,
+    Upload,
+    Publish,
+    Generate,
+    #[serde(other)]
+    Unknown,
+}
+
+impl Display for ClaimsScope {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", format!("{:?}", self).to_ascii_lowercase())
+    }
+}
+
 /* Claims are used in two forms, one for API calls, and one for
  * general repo access, the second one is simpler and just uses scope
  * for the allowed ids, and sub means the user doing the access (which
@@ -150,7 +169,7 @@ pub struct Claims {
 
     // Below are optional, and not used for repo tokens
     #[serde(default)]
-    pub scope: Vec<String>, // "build", "upload" "publish"
+    pub scope: Vec<ClaimsScope>,
     #[serde(default)]
     pub prefixes: Vec<String>, // [''] => all, ['org.foo'] => org.foo + org.foo.bar (but not org.foobar)
     #[serde(default)]

--- a/src/app.rs
+++ b/src/app.rs
@@ -7,6 +7,7 @@ use actix_web::http::header::{HeaderValue, CACHE_CONTROL};
 use actix_web::web::Data;
 use actix_web::Responder;
 use actix_web::{self, http, middleware, web, App, HttpRequest, HttpResponse, HttpServer};
+use futures3::TryFutureExt;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::ffi::OsStr;
@@ -153,6 +154,8 @@ pub enum ClaimsScope {
     Publish,
     // Permission to upload deltas for a repo. Should not be given to untrusted parties.
     Generate,
+    // Permission to list builds and to download a build repo.
+    Download,
     #[serde(other)]
     Unknown,
 }
@@ -378,15 +381,44 @@ pub fn load_config<P: AsRef<Path>>(path: P) -> io::Result<Config> {
     Ok(config_data)
 }
 
+#[derive(Deserialize)]
+pub struct BuildRepoParams {
+    id: i32,
+    tail: String,
+}
+
 fn handle_build_repo(
     config: Data<Config>,
+    params: actix_web::web::Path<BuildRepoParams>,
+    db: Data<Db>,
+    req: HttpRequest,
+) -> impl Future<Item = HttpResponse, Error = actix_web::Error> {
+    Box::pin(handle_build_repo_async(config, params, db, req)).compat()
+}
+
+async fn handle_build_repo_async(
+    config: Data<Config>,
+    params: actix_web::web::Path<BuildRepoParams>,
+    db: Data<Db>,
     req: HttpRequest,
 ) -> Result<HttpResponse, actix_web::Error> {
-    let tail = req.match_info().query("tail");
-    let id = req.match_info().query("id");
+    let build = db.lookup_build(params.id).await?;
+    if !build.public_download {
+        req.has_token_repo(&build.repo)?;
+        req.has_token_claims(&format!("build/{}", build.id), ClaimsScope::Download)?;
+        if let Some(app_id) = build.app_id {
+            req.has_token_prefix(&app_id)
+                /* Hide the app ID of the build, since we can't access it */
+                .map_err(|_| {
+                    ApiError::NotEnoughPermissions(
+                        "Build's app ID not matching prefix in token".to_string(),
+                    )
+                })?;
+        }
+    }
 
-    let relpath = canonicalize_path(tail.trim_start_matches('/'))?;
-    let realid = canonicalize_path(id)?;
+    let relpath = canonicalize_path(params.tail.trim_start_matches('/'))?;
+    let realid = canonicalize_path(&params.id.to_string())?;
     let path = Path::new(&config.build_repo_base)
         .join(&realid)
         .join(&relpath);
@@ -397,7 +429,7 @@ fn handle_build_repo(
     NamedFile::open(path)
         .or_else(|_e| {
             let fallback_path = Path::new(&config.build_repo_base)
-                .join(&id)
+                .join(&params.id.to_string())
                 .join("parent")
                 .join(&relpath);
             if fallback_path.is_dir() {

--- a/src/bin/delta-generator-client.rs
+++ b/src/bin/delta-generator-client.rs
@@ -431,7 +431,7 @@ impl WriteHandler<WsProtocolError> for DeltaClient {}
 
 fn main() {
     env::set_var("RUST_LOG", "info");
-    let _ = env_logger::init();
+    env_logger::init();
     let sys = actix::System::new("delta-generator-client");
 
     let cwd = std::env::current_dir().expect("Can't get cwd");

--- a/src/bin/gentoken.rs
+++ b/src/bin/gentoken.rs
@@ -53,7 +53,7 @@ fn main() {
         ap.refer(&mut scope).add_option(
             &["--scope"],
             List,
-            "Add scope (default if none: [build, upload, publish, jobs]",
+            "Add scope (default if none: [build, upload, download, publish, jobs]",
         );
         ap.refer(&mut prefixes).add_option(
             &["--prefix"],
@@ -88,6 +88,7 @@ fn main() {
         scope = vec![
             "build".to_string(),
             "upload".to_string(),
+            "download".to_string(),
             "publish".to_string(),
             "jobs".to_string(),
         ];

--- a/src/deltas.rs
+++ b/src/deltas.rs
@@ -23,7 +23,7 @@ use std::time::{Duration, Instant};
 const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(30);
 const CLIENT_TIMEOUT: Duration = Duration::from_secs(60);
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct DeltaRequest {
     pub repo: String,
     pub delta: ostree::Delta,

--- a/src/jobs.rs
+++ b/src/jobs.rs
@@ -9,6 +9,7 @@ use serde_json::json;
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 use std::ffi::OsString;
+use std::fmt::Write as _;
 use std::fs::{self, File};
 use std::io::Write;
 use std::iter::FromIterator;
@@ -115,22 +116,22 @@ Url={}
      */
     if let Some(collection_id) = &repoconfig.collection_id {
         if repoconfig.deploy_collection_id && maybe_build_id == None {
-            contents.push_str(&format!("DeployCollectionID={}\n", collection_id));
+            writeln!(contents, "DeployCollectionID={}", collection_id).unwrap();
         }
     };
 
     if maybe_build_id == None {
         if let Some(suggested_name) = &repoconfig.suggested_repo_name {
-            contents.push_str(&format!("SuggestRemoteName={}\n", suggested_name));
+            writeln!(contents, "SuggestRemoteName={}", suggested_name).unwrap();
         }
     }
 
     if let Some(gpg_content) = maybe_gpg_content {
-        contents.push_str(&format!("GPGKey={}\n", gpg_content))
+        writeln!(contents, "GPGKey={}", gpg_content).unwrap();
     }
 
     if let Some(runtime_repo_url) = &repoconfig.runtime_repo_url {
-        contents.push_str(&format!("RuntimeRepo={}\n", runtime_repo_url));
+        writeln!(contents, "RuntimeRepo={}\n", runtime_repo_url).unwrap();
     }
 
     (filename, contents)

--- a/src/models.rs
+++ b/src/models.rs
@@ -10,6 +10,7 @@ use std::{mem, time};
 pub struct NewBuild {
     pub repo: String,
     pub app_id: Option<String>,
+    pub public_download: bool,
 }
 
 #[derive(Identifiable, Serialize, Queryable, Debug, Eq, PartialEq)]
@@ -29,6 +30,7 @@ pub struct Build {
     pub repo: String,
     pub extra_ids: Vec<String>,
     pub app_id: Option<String>,
+    pub public_download: bool,
 }
 
 #[derive(Deserialize, Debug, Eq, PartialEq)]

--- a/src/models.rs
+++ b/src/models.rs
@@ -9,6 +9,7 @@ use std::{mem, time};
 #[table_name = "builds"]
 pub struct NewBuild {
     pub repo: String,
+    pub app_id: Option<String>,
 }
 
 #[derive(Identifiable, Serialize, Queryable, Debug, Eq, PartialEq)]

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,3 +1,6 @@
+/* see https://github.com/rust-lang/rust-clippy/issues/9014 */
+#![allow(clippy::extra_unused_lifetimes)]
+
 use crate::schema::{build_refs, builds, job_dependencies, jobs};
 use serde::{Deserialize, Serialize};
 use std::{mem, time};
@@ -8,7 +11,7 @@ pub struct NewBuild {
     pub repo: String,
 }
 
-#[derive(Identifiable, Serialize, Queryable, Debug, PartialEq)]
+#[derive(Identifiable, Serialize, Queryable, Debug, Eq, PartialEq)]
 pub struct Build {
     pub id: i32,
     pub created: chrono::NaiveDateTime,
@@ -26,7 +29,7 @@ pub struct Build {
     pub extra_ids: Vec<String>,
 }
 
-#[derive(Deserialize, Debug, PartialEq)]
+#[derive(Deserialize, Debug, Eq, PartialEq)]
 pub enum PublishedState {
     Unpublished,
     Publishing,
@@ -116,7 +119,7 @@ pub struct NewBuildRef {
     pub commit: String,
 }
 
-#[derive(Identifiable, Associations, Serialize, Queryable, PartialEq, Debug)]
+#[derive(Identifiable, Associations, Serialize, Queryable, Eq, PartialEq, Debug)]
 #[belongs_to(Build)]
 pub struct BuildRef {
     pub id: i32,
@@ -135,7 +138,7 @@ table! {
 
 allow_tables_to_appear_in_same_query!(jobs, job_dependencies_with_status,);
 
-#[derive(Deserialize, Debug, PartialEq)]
+#[derive(Deserialize, Debug, Eq, PartialEq)]
 pub enum JobStatus {
     New,
     Started,
@@ -155,7 +158,7 @@ impl JobStatus {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum JobKind {
     Commit,
     Publish,
@@ -190,7 +193,7 @@ pub struct NewJob {
     pub repo: Option<String>,
 }
 
-#[derive(Identifiable, Serialize, Queryable, Debug, PartialEq)]
+#[derive(Identifiable, Serialize, Queryable, Debug, Eq, PartialEq)]
 pub struct Job {
     pub id: i32,
     pub kind: i16,

--- a/src/models.rs
+++ b/src/models.rs
@@ -27,6 +27,7 @@ pub struct Build {
     pub publish_job_id: Option<i32>,
     pub repo: String,
     pub extra_ids: Vec<String>,
+    pub app_id: Option<String>,
 }
 
 #[derive(Deserialize, Debug, Eq, PartialEq)]

--- a/src/ostree.rs
+++ b/src/ostree.rs
@@ -16,7 +16,7 @@ use std::{collections::HashMap, path::Path};
 use tokio_process::CommandExt;
 use walkdir::WalkDir;
 
-#[derive(Fail, Debug, Clone, PartialEq)]
+#[derive(Fail, Debug, Clone, Eq, PartialEq)]
 pub enum OstreeError {
     #[fail(display = "No such ref: {}", _0)]
     NoSuchRef(String),

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -19,6 +19,7 @@ table! {
         publish_job_id -> Nullable<Int4>,
         repo -> Text,
         extra_ids -> Array<Text>,
+        app_id -> Nullable<Text>,
     }
 }
 

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -20,6 +20,7 @@ table! {
         repo -> Text,
         extra_ids -> Array<Text>,
         app_id -> Nullable<Text>,
+        public_download -> Bool,
     }
 }
 

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -8,7 +8,7 @@ use futures::{Future, Poll};
 use jwt::{decode, DecodingKey, Validation};
 use std::rc::Rc;
 
-use crate::app::Claims;
+use crate::app::{Claims, ClaimsScope};
 use crate::errors::ApiError;
 
 pub trait ClaimsValidator {
@@ -16,7 +16,7 @@ pub trait ClaimsValidator {
     fn validate_claims<Func>(&self, func: Func) -> Result<(), ApiError>
     where
         Func: Fn(&Claims) -> Result<(), ApiError>;
-    fn has_token_claims(&self, required_sub: &str, required_scope: &str) -> Result<(), ApiError>;
+    fn has_token_claims(&self, required_sub: &str, required_scope: ClaimsScope) -> Result<(), ApiError>;
     fn has_token_prefix(&self, id: &str) -> Result<(), ApiError>;
     fn has_token_repo(&self, repo: &str) -> Result<(), ApiError>;
 }
@@ -80,7 +80,7 @@ impl ClaimsValidator for HttpRequest {
         }
     }
 
-    fn has_token_claims(&self, required_sub: &str, required_scope: &str) -> Result<(), ApiError> {
+    fn has_token_claims(&self, required_sub: &str, required_scope: ClaimsScope) -> Result<(), ApiError> {
         self.validate_claims(|claims| {
             // Matches using a path-prefix style comparison:
             //  claim.sub == "build" should match required_sub == "build" or "build/N[/...]"
@@ -91,7 +91,7 @@ impl ClaimsValidator for HttpRequest {
                     required_sub
                 )));
             }
-            if !claims.scope.contains(&required_scope.to_string()) {
+            if !claims.scope.contains(&required_scope) {
                 return Err(ApiError::NotEnoughPermissions(format!(
                     "Not matching scope '{}' in token",
                     required_scope

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -16,7 +16,11 @@ pub trait ClaimsValidator {
     fn validate_claims<Func>(&self, func: Func) -> Result<(), ApiError>
     where
         Func: Fn(&Claims) -> Result<(), ApiError>;
-    fn has_token_claims(&self, required_sub: &str, required_scope: ClaimsScope) -> Result<(), ApiError>;
+    fn has_token_claims(
+        &self,
+        required_sub: &str,
+        required_scope: ClaimsScope,
+    ) -> Result<(), ApiError>;
     fn has_token_prefix(&self, id: &str) -> Result<(), ApiError>;
     fn has_token_repo(&self, repo: &str) -> Result<(), ApiError>;
 }
@@ -80,7 +84,11 @@ impl ClaimsValidator for HttpRequest {
         }
     }
 
-    fn has_token_claims(&self, required_sub: &str, required_scope: ClaimsScope) -> Result<(), ApiError> {
+    fn has_token_claims(
+        &self,
+        required_sub: &str,
+        required_scope: ClaimsScope,
+    ) -> Result<(), ApiError> {
         self.validate_claims(|claims| {
             // Matches using a path-prefix style comparison:
             //  claim.sub == "build" should match required_sub == "build" or "build/N[/...]"


### PR DESCRIPTION
Adds an optional app ID field to builds. Builds with an app ID require that app ID to be present in the token's `prefixes` field, protecting them from other users.

This change doesn't affect existing build tokens or processes, but once it is merged, build processes should be updated to create their builds with an app ID.

Also adds private builds, which also require a token to download from the build repo.