### PR TITLE
delta-generator-client: add CDN_URL env to set the cdn to download deltas from

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ need to be installed first. On Fedora, this is done with:
 
     sudo dnf install postgresql-devel
 
+You also need ostree. On Fedora, this is done with:
+
+    sudo dnf install ostree-devel
+
 Then build the server by running:
 
     cargo build

--- a/src/bin/delta-generator-client.rs
+++ b/src/bin/delta-generator-client.rs
@@ -185,12 +185,11 @@ fn pull_and_generate_delta_async(
     url: &str,
     delta: &ostree::Delta,
 ) -> Box<dyn Future<Item = (), Error = DeltaGenerationError>> {
-    let url = url.to_string();
     let repo_path2 = repo_path.to_path_buf();
     let delta_clone = delta.clone();
     Box::new(
         // We do 5 retries, because pull is sometimes not super stable
-        ostree::pull_delta_async(5, repo_path, &url, &delta_clone)
+        ostree::pull_delta_async(5, repo_path, url, &delta_clone)
             .and_then(move |_| ostree::generate_delta_async(&repo_path2, &delta_clone))
             .from_err(),
     )


### PR DESCRIPTION
set `CDN_URL` to set the CDN url to download delta from

@barthalion this is based on your patch.

Note: it has been poorly tested.