### PR TITLE
Add gpg2 symlink to dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,8 @@ FROM ubuntu:22.04
 RUN apt-get update && apt-get install -y flatpak ostree libpq5 ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 
+RUN ln -s /usr/bin/gpg /usr/bin/gpg2
+
 ADD https://github.com/openSUSE/catatonit/releases/download/v0.1.7/catatonit.x86_64 /usr/local/bin/catatonit
 RUN chmod +x /usr/local/bin/catatonit
 


### PR DESCRIPTION
Fixes #90

A possible alternative would be to change flat-manager to use gpg.
https://github.com/flatpak/flat-manager/blob/f6ef84fc39659065c7323e7680adff20add9068a/src/app.rs#L27