### PR TITLE
review-check: Allow setting the check results

### DIFF
--- a/src/api/build.rs
+++ b/src/api/build.rs
@@ -60,6 +60,7 @@ async fn get_job_async(
 #[serde(rename_all = "kebab-case")]
 pub struct ReviewArgs {
     new_status: CheckStatus,
+    new_results: Option<String>,
 }
 
 pub fn review_check(
@@ -79,7 +80,7 @@ async fn review_check_async(
 ) -> Result<HttpResponse, ApiError> {
     req.has_token_claims("build", ClaimsScope::ReviewCheck)?;
 
-    db.set_check_status(params.id, args.new_status.clone())
+    db.set_check_status(params.id, args.new_status.clone(), args.new_results.clone())
         .await?;
 
     let check = db.get_check_by_job_id(params.id).await?;

--- a/src/db.rs
+++ b/src/db.rs
@@ -271,13 +271,19 @@ impl Db {
         &self,
         job: i32,
         new_status: CheckStatus,
+        new_results: Option<String>,
     ) -> Result<(), ApiError> {
         self.run(move |conn| {
             use schema::checks::dsl;
             let (status, status_reason) = new_status.to_db();
+
             diesel::update(dsl::checks)
                 .filter(dsl::job_id.eq(job))
-                .set((dsl::status.eq(status), dsl::status_reason.eq(status_reason)))
+                .set((
+                    dsl::status.eq(status),
+                    dsl::status_reason.eq(status_reason),
+                    new_results.map(|r| dsl::results.eq(r)),
+                ))
                 .execute(conn)?;
             Ok(())
         })


### PR DESCRIPTION
This field is intended for a machine-readable description of the check's original results (separate from the status reason, which may change when the check is reviewed).