### PR TITLE
Add build log URL field to builds and build refs

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,11 @@ config file; see `example-config.json`.
 
 The publish hook runs in the build directory before a build is published
 to a main repository. It can modify the build, for example by rewriting
-the appstream files in the commits.
+the appstream files in the commits. It receives the `FLAT_MANAGER_IS_REPUBLISH`
+environment variable, which is `true` if the publish was triggered by the
+republish endpoint or `false` if the publish is part of a build.
+If the publish is part of the build, the hook also receives the
+`FLAT_MANAGER_BUILD_ID` environment variable.
 
 Check scripts are run after a build is uploaded. Builds may not be
 published unless all checks have passed. The check is marked as failed

--- a/flat-manager-client
+++ b/flat-manager-client
@@ -298,9 +298,13 @@ async def upload_objects(session, repo_path, build_url, token, objects):
     retry=TENACITY_RETRY_EXCEPTIONS,
     reraise=True,
 )
-async def create_ref(session, build_url, token, ref, commit):
+async def create_ref(session, build_url, token, ref, commit, build_log_url=None):
     print("Creating ref %s with commit %s" % (ref, commit))
-    resp = await session.post(build_url + "/build_ref", headers={'Authorization': 'Bearer ' + token}, json= { "ref": ref, "commit": commit} )
+    resp = await session.post(
+        build_url + "/build_ref",
+        headers={ 'Authorization': 'Bearer ' + token },
+        json= { "ref": ref, "commit": commit, "build-log-url": build_log_url }
+    )
     async with resp:
         if resp.status != 200:
             raise ApiError(resp, await resp.text())
@@ -557,6 +561,8 @@ async def create_command(session, args):
         json["app-id"] = args.app_id
     if args.public_download is not None:
         json["public-download"] = args.public_download
+    if args.build_log_url is not None:
+        json["build-log-url"] = args.build_log_url
     resp = await session.post(build_url, headers={'Authorization': 'Bearer ' + args.token}, json=json)
     async with resp:
         if resp.status != 200:
@@ -645,7 +651,7 @@ async def push_command(session, args):
 
     # Then the refs
     for ref, commit in refs.items():
-        await create_ref(session, args.build_url, token, ref, commit)
+        await create_ref(session, args.build_url, token, ref, commit, build_log_url=args.build_log_url)
 
     # Then any extra ids
     if args.extra_id:
@@ -744,6 +750,7 @@ if __name__ == '__main__':
     create_parser.add_argument('app_id', nargs='?', help='app ID')
     create_parser.add_argument('--public_download', action='store_true', default=None, help='allow public read access to the build repo')
     create_parser.add_argument('--no_public_download', action='store_false', dest='public_download', default=None, help='allow public read access to the build repo')
+    create_parser.add_argument('--build-log-url', help='Set URL of the build log for the whole build')
     create_parser.set_defaults(func=create_command)
 
     push_parser = subparsers.add_parser('push', help='Push to repo manager')
@@ -765,6 +772,7 @@ if __name__ == '__main__':
     push_parser.add_argument('--end-of-life', help='Set end of life')
     push_parser.add_argument('--end-of-life-rebase', help='Set new ID which will supercede the current one')
     push_parser.add_argument('--token-type', help='Set token type', type=int)
+    push_parser.add_argument('--build-log-url', help='Set URL of the build log for each uploaded ref')
     push_parser.set_defaults(func=push_command)
 
     commit_parser = subparsers.add_parser('commit', help='Commit build')

--- a/migrations/2023-06-14-145148_build_log_url/down.sql
+++ b/migrations/2023-06-14-145148_build_log_url/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE builds DROP COLUMN build_log_url;
+ALTER TABLE build_refs DROP COLUMN build_log_url;

--- a/migrations/2023-06-14-145148_build_log_url/up.sql
+++ b/migrations/2023-06-14-145148_build_log_url/up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE builds ADD build_log_url TEXT;
+ALTER TABLE build_refs ADD build_log_url TEXT;

--- a/src/app.rs
+++ b/src/app.rs
@@ -113,6 +113,11 @@ pub fn create_app(
                             .route(web::get().to_async(api::build::get_build)),
                     )
                     .service(
+                        web::resource("/build/{id}/extended")
+                            .name("show_build_extended")
+                            .route(web::get().to_async(api::build::get_build_extended)),
+                    )
+                    .service(
                         web::resource("/build/{id}/build_ref")
                             .route(web::post().to_async(api::build::create_build_ref)),
                     )

--- a/src/db.rs
+++ b/src/db.rs
@@ -290,6 +290,16 @@ impl Db {
         .await
     }
 
+    pub async fn lookup_checks(&self, build: i32) -> Result<Vec<Check>, ApiError> {
+        self.run(move |conn| {
+            use schema::checks::dsl::*;
+            Ok(checks
+                .filter(build_id.eq(build))
+                .get_results::<Check>(conn)?)
+        })
+        .await
+    }
+
     /* Builds */
 
     pub async fn new_build(&self, a_build: NewBuild) -> Result<Build, ApiError> {
@@ -342,8 +352,8 @@ impl Db {
 
             let mut new_ids = current_build.extra_ids;
             for new_id in ids.iter() {
-                if !new_ids.contains(new_id) {
-                    new_ids.push(new_id.to_string())
+                if !new_ids.iter().any(|id| id.as_ref() == Some(new_id)) {
+                    new_ids.push(Some(new_id.to_string()))
                 }
             }
             Ok(diesel::update(schema::builds::table)
@@ -442,7 +452,6 @@ impl Db {
         .await
     }
 
-    #[allow(dead_code)]
     pub async fn lookup_build_refs(&self, the_build_id: i32) -> Result<Vec<BuildRef>, ApiError> {
         self.run(move |conn| {
             use schema::build_refs::dsl::*;

--- a/src/jobs/publish_job.rs
+++ b/src/jobs/publish_job.rs
@@ -73,7 +73,8 @@ impl PublishJobInstance {
         add_gpg_args(&mut cmd, &repoconfig.gpg_key, &config.gpg_homedir);
 
         if let Some(collection_id) = &repoconfig.collection_id {
-            for ref extra_id in build.extra_ids.iter() {
+            for extra_id in build.extra_ids.iter() {
+                let extra_id = extra_id.as_ref().expect("extra_id is null");
                 cmd.arg(format!("--extra-collection-id={collection_id}.{extra_id}"));
             }
         }

--- a/src/jobs/publish_job.rs
+++ b/src/jobs/publish_job.rs
@@ -50,13 +50,17 @@ impl PublishJobInstance {
         let build_repo_path = config.build_repo_base.join(self.build_id.to_string());
 
         // Run the publish hook, if any
-        if let Some(hook) = repoconfig
+        if let Some(mut hook) = repoconfig
             .hooks
             .publish
             .as_ref()
             .and_then(|x| x.build_command(&build_repo_path))
         {
             job_log_and_info!(self.job_id, conn, "Running publish hook");
+
+            hook.env("FLAT_MANAGER_IS_REPUBLISH", "false");
+            hook.env("FLAT_MANAGER_BUILD_ID", build.id.to_string());
+
             do_command(hook)?;
         }
 

--- a/src/jobs/republish_job.rs
+++ b/src/jobs/republish_job.rs
@@ -124,13 +124,16 @@ impl JobInstance for RepublishJobInstance {
         }
 
         // Run the publish hook, if any
-        if let Some(hook) = repoconfig
+        if let Some(mut hook) = repoconfig
             .hooks
             .publish
             .as_ref()
             .and_then(|x| x.build_command(tmp_repo_dir.path()))
         {
             job_log_and_info!(self.job_id, conn, "Running publish hook");
+
+            hook.env("FLAT_MANAGER_IS_REPUBLISH", "true");
+
             do_command(hook)?;
         }
 

--- a/src/models.rs
+++ b/src/models.rs
@@ -12,6 +12,7 @@ pub struct NewBuild {
     pub repo: String,
     pub app_id: Option<String>,
     pub public_download: bool,
+    pub build_log_url: Option<String>,
 }
 
 #[derive(Identifiable, Serialize, Queryable, Debug, Eq, PartialEq)]
@@ -29,9 +30,10 @@ pub struct Build {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub publish_job_id: Option<i32>,
     pub repo: String,
-    pub extra_ids: Vec<String>,
+    pub extra_ids: Vec<Option<String>>,
     pub app_id: Option<String>,
     pub public_download: bool,
+    pub build_log_url: Option<String>,
 }
 
 #[derive(Deserialize, Debug, Eq, PartialEq)]
@@ -132,6 +134,7 @@ pub struct NewBuildRef {
     pub build_id: i32,
     pub ref_name: String,
     pub commit: String,
+    pub build_log_url: Option<String>,
 }
 
 #[derive(Identifiable, Associations, Serialize, Queryable, Eq, PartialEq, Debug)]
@@ -141,6 +144,7 @@ pub struct BuildRef {
     pub build_id: i32,
     pub ref_name: String,
     pub commit: String,
+    pub build_log_url: Option<String>,
 }
 
 diesel::table! {
@@ -311,7 +315,7 @@ impl CheckStatus {
     }
 }
 
-#[derive(Debug, Queryable, Insertable, Identifiable, Associations)]
+#[derive(Debug, Queryable, Insertable, Identifiable, Associations, Serialize)]
 #[diesel(primary_key(check_name, build_id))]
 #[diesel(belongs_to(Build, foreign_key = build_id))]
 #[diesel(belongs_to(Job, foreign_key = job_id))]

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1,9 +1,12 @@
+// @generated automatically by Diesel CLI.
+
 diesel::table! {
     build_refs (id) {
         id -> Int4,
         build_id -> Int4,
         ref_name -> Text,
         commit -> Text,
+        build_log_url -> Nullable<Text>,
     }
 }
 
@@ -18,9 +21,10 @@ diesel::table! {
         commit_job_id -> Nullable<Int4>,
         publish_job_id -> Nullable<Int4>,
         repo -> Text,
-        extra_ids -> Array<Text>,
+        extra_ids -> Array<Nullable<Text>>,
         app_id -> Nullable<Text>,
         public_download -> Bool,
+        build_log_url -> Nullable<Text>,
     }
 }
 


### PR DESCRIPTION
When creating a build or a build ref, you can specify the URL to the build log. The publish hook will be able to insert this data into the appstream file.