### PR TITLE
flat-manager-client: Wait for check jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,11 @@ config file; see `example-config.json`.
 
 The publish hook runs in the build directory before a build is published
 to a main repository. It can modify the build, for example by rewriting
-the appstream files in the commits.
+the appstream files in the commits. It receives the `FLAT_MANAGER_IS_REPUBLISH`
+environment variable, which is `true` if the publish was triggered by the
+republish endpoint or `false` if the publish is part of a build.
+If the publish is part of the build, the hook also receives the
+`FLAT_MANAGER_BUILD_ID` environment variable.
 
 Check scripts are run after a build is uploaded. Builds may not be
 published unless all checks have passed. The check is marked as failed

--- a/flat-manager-client
+++ b/flat-manager-client
@@ -455,7 +455,7 @@ async def wait_for_checks(session, build_url, token):
 
         for check in build["checks"]:
             print("Waiting for check: %s" % (check["check_name"]))
-            job_url = build_url_to_api(build_url) + "/job/" + str(check["job_id"])
+            job_url = build_url + "/check/" + check["check_name"] + "/job"
             await wait_for_job(session, job_url, token)
 
 @retry(

--- a/flat-manager-client
+++ b/flat-manager-client
@@ -298,9 +298,13 @@ async def upload_objects(session, repo_path, build_url, token, objects):
     retry=TENACITY_RETRY_EXCEPTIONS,
     reraise=True,
 )
-async def create_ref(session, build_url, token, ref, commit):
+async def create_ref(session, build_url, token, ref, commit, build_log_url=None):
     print("Creating ref %s with commit %s" % (ref, commit))
-    resp = await session.post(build_url + "/build_ref", headers={'Authorization': 'Bearer ' + token}, json= { "ref": ref, "commit": commit} )
+    resp = await session.post(
+        build_url + "/build_ref",
+        headers={ 'Authorization': 'Bearer ' + token },
+        json= { "ref": ref, "commit": commit, "build-log-url": build_log_url }
+    )
     async with resp:
         if resp.status != 200:
             raise ApiError(resp, await resp.text())
@@ -557,6 +561,8 @@ async def create_command(session, args):
         json["app-id"] = args.app_id
     if args.public_download is not None:
         json["public-download"] = args.public_download
+    if args.build_log_url is not None:
+        json["build-log-url"] = args.build_log_url
     resp = await session.post(build_url, headers={'Authorization': 'Bearer ' + args.token}, json=json)
     async with resp:
         if resp.status != 200:
@@ -645,7 +651,7 @@ async def push_command(session, args):
 
     # Then the refs
     for ref, commit in refs.items():
-        await create_ref(session, args.build_url, token, ref, commit)
+        await create_ref(session, args.build_url, token, ref, commit, build_log_url=args.build_log_url)
 
     # Then any extra ids
     if args.extra_id:
@@ -744,6 +750,7 @@ if __name__ == '__main__':
     create_parser.add_argument('app_id', nargs='?', help='app ID')
     create_parser.add_argument('--public_download', action='store_true', default=None, help='allow public read access to the build repo')
     create_parser.add_argument('--no_public_download', action='store_false', dest='public_download', default=None, help='allow public read access to the build repo')
+    create_parser.add_argument('--build-log-url', help='Set URL of the build log for the whole build')
     create_parser.set_defaults(func=create_command)
 
     push_parser = subparsers.add_parser('push', help='Push to repo manager')
@@ -765,6 +772,7 @@ if __name__ == '__main__':
     push_parser.add_argument('--end-of-life', help='Set end of life')
     push_parser.add_argument('--end-of-life-rebase', help='Set new ID which will supercede the current one')
     push_parser.add_argument('--token-type', help='Set token type', type=int)
+    push_parser.add_argument('--build-log-url', help='Set URL of the build log for each uploaded ref')
     push_parser.set_defaults(func=push_command)
 
     commit_parser = subparsers.add_parser('commit', help='Commit build')

--- a/flat-manager-client
+++ b/flat-manager-client
@@ -490,6 +490,9 @@ async def publish_build(session, build_url, wait, token):
                 if body.get("current-state") == "published":
                     print("the build has been already published")
                     return {}
+                elif body.get("current-state") == "failed":
+                    print("the build has failed")
+                    return {}
             except:
                 pass
 

--- a/flat-manager-client
+++ b/flat-manager-client
@@ -439,6 +439,24 @@ async def wait_for_job(session, job_url, token):
             sleep_time=60
         time.sleep(sleep_time)
 
+@retry(
+    stop=TENACITY_STOP_AFTER,
+    wait=TENACITY_WAIT_BETWEEN,
+    retry=TENACITY_RETRY_EXCEPTIONS,
+    reraise=True,
+)
+async def wait_for_checks(session, build_url, token):
+    print("Waiting for checks, if any...")
+    resp = await session.get(build_url + "/extended", headers={'Authorization': 'Bearer ' + token})
+    async with resp:
+        if resp.status != 200:
+            raise ApiError(resp, await resp.text())
+        build = await resp.json()
+
+        for check in build["checks"]:
+            print("Waiting for check: %s" % (check["check_name"]))
+            job_url = build_url_to_api(build_url) + "/job/" + str(check["job_id"])
+            await wait_for_job(session, job_url, token)
 
 @retry(
     stop=TENACITY_STOP_AFTER,
@@ -464,7 +482,9 @@ async def commit_build(session, build_url, eol, eol_rebase, token_type, wait, to
 
         if wait:
             print("Waiting for commit job")
-            job = await wait_for_job(session, job_url, token);
+            job = await wait_for_job(session, job_url, token)
+
+            await wait_for_checks(session, build_url, token)
 
         reparse_job_results(job)
         job["location"] = job_url
@@ -487,11 +507,16 @@ async def publish_build(session, build_url, wait, token):
                 if isinstance(body, str):
                     body = json.loads(body)
 
-                if body.get("current-state") == "published":
+                current_state = body.get("current-state", None)
+
+                if current_state == "published":
                     print("the build has been already published")
                     return {}
-                elif body.get("current-state") == "failed":
+                elif current_state == "failed":
                     print("the build has failed")
+                    return {}
+                elif current_state == "validating":
+                    print("the build is still being validated")
                     return {}
             except:
                 pass

--- a/migrations/2023-06-14-145148_build_log_url/down.sql
+++ b/migrations/2023-06-14-145148_build_log_url/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE builds DROP COLUMN build_log_url;
+ALTER TABLE build_refs DROP COLUMN build_log_url;

--- a/migrations/2023-06-14-145148_build_log_url/up.sql
+++ b/migrations/2023-06-14-145148_build_log_url/up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE builds ADD build_log_url TEXT;
+ALTER TABLE build_refs ADD build_log_url TEXT;

--- a/src/api/build.rs
+++ b/src/api/build.rs
@@ -19,7 +19,7 @@ use crate::config::Config;
 use crate::db::*;
 use crate::errors::ApiError;
 use crate::jobs::{update_build_status_after_check, JobQueue, ProcessJobs};
-use crate::models::{Build, CheckStatus, NewBuild, NewBuildRef};
+use crate::models::{Build, BuildRef, Check, CheckStatus, NewBuild, NewBuildRef};
 use crate::ostree::init_ostree_repo;
 use crate::tokens::{self, Claims, ClaimsScope, ClaimsValidator};
 
@@ -100,6 +100,7 @@ pub struct CreateBuildArgs {
     repo: String,
     app_id: Option<String>,
     public_download: Option<bool>,
+    build_log_url: Option<String>,
 }
 
 pub fn create_build(
@@ -137,6 +138,7 @@ async fn create_build_async(
             repo: args.repo.clone(),
             app_id: args.app_id.clone(),
             public_download,
+            build_log_url: args.build_log_url.clone(),
         })
         .await?;
     let build_repo_path = config.build_repo_base.join(build.id.to_string());
@@ -227,6 +229,42 @@ async fn get_build_async(
     has_token_for_build(&req, &build)?;
 
     Ok(HttpResponse::Ok().json(build))
+}
+
+pub fn get_build_extended(
+    params: Path<BuildPathParams>,
+    db: Data<Db>,
+    req: HttpRequest,
+) -> impl Future<Item = HttpResponse, Error = ApiError> {
+    Box::pin(get_build_extended_async(params, db, req)).compat()
+}
+
+#[derive(Debug, Serialize)]
+pub struct BuildExtended {
+    build: Build,
+    build_refs: Vec<BuildRef>,
+    checks: Vec<Check>,
+}
+
+async fn get_build_extended_async(
+    params: Path<BuildPathParams>,
+    db: Data<Db>,
+    req: HttpRequest,
+) -> Result<HttpResponse, ApiError> {
+    req.has_token_claims(&format!("build/{}", params.id), ClaimsScope::Build)
+        .or_else(|_| req.has_token_claims(&format!("build/{}", params.id), ClaimsScope::Upload))?;
+
+    let build = db.lookup_build(params.id).await?;
+    has_token_for_build(&req, &build)?;
+
+    let build_refs = db.lookup_build_refs(params.id).await?;
+    let checks = db.lookup_checks(params.id).await?;
+
+    Ok(HttpResponse::Ok().json(BuildExtended {
+        build,
+        build_refs,
+        checks,
+    }))
 }
 
 #[derive(Deserialize)]
@@ -341,10 +379,12 @@ fn validate_ref(ref_name: &str, req: &HttpRequest) -> Result<(), ApiError> {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
 pub struct CreateBuildRefArgs {
     #[serde(rename = "ref")]
     ref_name: String,
     commit: String,
+    build_log_url: Option<String>,
 }
 
 pub fn create_build_ref(
@@ -375,6 +415,7 @@ async fn create_build_ref_async(
             build_id,
             ref_name: args.ref_name.clone(),
             commit: args.commit.clone(),
+            build_log_url: args.build_log_url.clone(),
         })
         .await?;
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -152,6 +152,11 @@ pub fn create_app(
                             .route(web::get().to_async(api::build::get_publish_job)),
                     )
                     .service(
+                        web::resource("/build/{id}/check/{check_name}/job")
+                            .name("show_check_job")
+                            .route(web::get().to_async(api::build::get_check_job)),
+                    )
+                    .service(
                         web::resource("/build/{id}/purge")
                             .route(web::post().to_async(api::build::purge)),
                     )

--- a/src/app.rs
+++ b/src/app.rs
@@ -113,6 +113,11 @@ pub fn create_app(
                             .route(web::get().to_async(api::build::get_build)),
                     )
                     .service(
+                        web::resource("/build/{id}/extended")
+                            .name("show_build_extended")
+                            .route(web::get().to_async(api::build::get_build_extended)),
+                    )
+                    .service(
                         web::resource("/build/{id}/build_ref")
                             .route(web::post().to_async(api::build::create_build_ref)),
                     )

--- a/src/jobs/check_job.rs
+++ b/src/jobs/check_job.rs
@@ -140,7 +140,10 @@ impl JobInstance for CheckJobInstance {
                 job_log_and_info!(
                     self.job_id,
                     conn,
-                    format!("Check status updated to {:?}", check.status)
+                    format!(
+                        "Check status updated to {:?}",
+                        CheckStatus::from_db(check.status, check.status_reason)
+                    )
                 );
             }
 

--- a/src/jobs/check_job.rs
+++ b/src/jobs/check_job.rs
@@ -130,6 +130,18 @@ impl JobInstance for CheckJobInstance {
                         checks::status_reason.eq(status_reason),
                     ))
                     .get_result::<Check>(conn)?;
+
+                job_log_and_info!(
+                    self.job_id,
+                    conn,
+                    format!("Check status updated to {new_status:?}")
+                );
+            } else {
+                job_log_and_info!(
+                    self.job_id,
+                    conn,
+                    format!("Check status updated to {:?}", check.status)
+                );
             }
 
             update_build_status_after_check(self.build_id, conn)?;

--- a/src/jobs/publish_job.rs
+++ b/src/jobs/publish_job.rs
@@ -73,7 +73,8 @@ impl PublishJobInstance {
         add_gpg_args(&mut cmd, &repoconfig.gpg_key, &config.gpg_homedir);
 
         if let Some(collection_id) = &repoconfig.collection_id {
-            for ref extra_id in build.extra_ids.iter() {
+            for extra_id in build.extra_ids.iter() {
+                let extra_id = extra_id.as_ref().expect("extra_id is null");
                 cmd.arg(format!("--extra-collection-id={collection_id}.{extra_id}"));
             }
         }

--- a/src/jobs/publish_job.rs
+++ b/src/jobs/publish_job.rs
@@ -50,13 +50,17 @@ impl PublishJobInstance {
         let build_repo_path = config.build_repo_base.join(self.build_id.to_string());
 
         // Run the publish hook, if any
-        if let Some(hook) = repoconfig
+        if let Some(mut hook) = repoconfig
             .hooks
             .publish
             .as_ref()
             .and_then(|x| x.build_command(&build_repo_path))
         {
             job_log_and_info!(self.job_id, conn, "Running publish hook");
+
+            hook.env("FLAT_MANAGER_IS_REPUBLISH", "false");
+            hook.env("FLAT_MANAGER_BUILD_ID", build.id.to_string());
+
             do_command(hook)?;
         }
 

--- a/src/jobs/republish_job.rs
+++ b/src/jobs/republish_job.rs
@@ -124,13 +124,16 @@ impl JobInstance for RepublishJobInstance {
         }
 
         // Run the publish hook, if any
-        if let Some(hook) = repoconfig
+        if let Some(mut hook) = repoconfig
             .hooks
             .publish
             .as_ref()
             .and_then(|x| x.build_command(tmp_repo_dir.path()))
         {
             job_log_and_info!(self.job_id, conn, "Running publish hook");
+
+            hook.env("FLAT_MANAGER_IS_REPUBLISH", "true");
+
             do_command(hook)?;
         }
 

--- a/src/models.rs
+++ b/src/models.rs
@@ -12,6 +12,7 @@ pub struct NewBuild {
     pub repo: String,
     pub app_id: Option<String>,
     pub public_download: bool,
+    pub build_log_url: Option<String>,
 }
 
 #[derive(Identifiable, Serialize, Queryable, Debug, Eq, PartialEq)]
@@ -29,9 +30,10 @@ pub struct Build {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub publish_job_id: Option<i32>,
     pub repo: String,
-    pub extra_ids: Vec<String>,
+    pub extra_ids: Vec<Option<String>>,
     pub app_id: Option<String>,
     pub public_download: bool,
+    pub build_log_url: Option<String>,
 }
 
 #[derive(Deserialize, Debug, Eq, PartialEq)]
@@ -132,6 +134,7 @@ pub struct NewBuildRef {
     pub build_id: i32,
     pub ref_name: String,
     pub commit: String,
+    pub build_log_url: Option<String>,
 }
 
 #[derive(Identifiable, Associations, Serialize, Queryable, Eq, PartialEq, Debug)]
@@ -141,6 +144,7 @@ pub struct BuildRef {
     pub build_id: i32,
     pub ref_name: String,
     pub commit: String,
+    pub build_log_url: Option<String>,
 }
 
 diesel::table! {
@@ -311,7 +315,7 @@ impl CheckStatus {
     }
 }
 
-#[derive(Debug, Queryable, Insertable, Identifiable, Associations)]
+#[derive(Debug, Queryable, Insertable, Identifiable, Associations, Serialize)]
 #[diesel(primary_key(check_name, build_id))]
 #[diesel(belongs_to(Build, foreign_key = build_id))]
 #[diesel(belongs_to(Job, foreign_key = job_id))]

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1,9 +1,12 @@
+// @generated automatically by Diesel CLI.
+
 diesel::table! {
     build_refs (id) {
         id -> Int4,
         build_id -> Int4,
         ref_name -> Text,
         commit -> Text,
+        build_log_url -> Nullable<Text>,
     }
 }
 
@@ -18,9 +21,10 @@ diesel::table! {
         commit_job_id -> Nullable<Int4>,
         publish_job_id -> Nullable<Int4>,
         repo -> Text,
-        extra_ids -> Array<Text>,
+        extra_ids -> Array<Nullable<Text>>,
         app_id -> Nullable<Text>,
         public_download -> Bool,
+        build_log_url -> Nullable<Text>,
     }
 }
 


### PR DESCRIPTION
When flat-manager-client waits for the commit job, it also waits for check jobs.

Also, if the build has failed or is still validating, don't retry publishing it.

Depends on #100 and #107.