### PR TITLE
Add builder_id to builds

### DIFF
--- a/migrations/2023-08-09-160537_builder_id/down.sql
+++ b/migrations/2023-08-09-160537_builder_id/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE builds DROP COLUMN builder_id;

--- a/migrations/2023-08-09-160537_builder_id/up.sql
+++ b/migrations/2023-08-09-160537_builder_id/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE builds ADD builder_id TEXT;

--- a/src/api/build.rs
+++ b/src/api/build.rs
@@ -140,6 +140,7 @@ async fn create_build_async(
             app_id: args.app_id.clone(),
             public_download,
             build_log_url: args.build_log_url.clone(),
+            builder_id: req.get_claims().unwrap().builder_id.clone(),
         })
         .await?;
     let build_repo_path = config.build_repo_base.join(build.id.to_string());
@@ -536,6 +537,7 @@ pub fn token_subset(
                 scope: args.scope.clone(),
                 name: Some(claims.name.unwrap_or_default() + "/" + &args.name),
                 jti: claims.jti.clone(),
+                builder_id: claims.builder_id.clone(),
                 prefixes: {
                     if let Some(ref prefixes) = args.prefixes {
                         prefixes.clone()

--- a/src/bin/gentoken.rs
+++ b/src/bin/gentoken.rs
@@ -16,6 +16,8 @@ struct Claims {
     prefixes: Vec<String>,
     repos: Vec<String>,
     exp: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    builder_id: Option<String>,
 }
 
 fn read_secret(filename: String) -> io::Result<String> {
@@ -40,6 +42,7 @@ fn main() {
     let mut scope: Vec<String> = vec![];
     let mut prefixes: Vec<String> = vec![];
     let mut repos: Vec<String> = vec![];
+    let mut builder_id: Option<String> = None;
 
     {
         let mut ap = ArgumentParser::new();
@@ -78,6 +81,11 @@ fn main() {
             &["--duration"],
             Store,
             "Duration for key in seconds (default 1 year)",
+        );
+        ap.refer(&mut builder_id).add_option(
+            &["--builder-id"],
+            StoreOption,
+            "Builder ID (default: none)",
         );
         ap.parse_args_or_exit();
     }
@@ -130,6 +138,7 @@ fn main() {
         repos,
         name: name.clone(),
         exp: Utc::now().timestamp() + duration,
+        builder_id,
     };
 
     if verbose {

--- a/src/models.rs
+++ b/src/models.rs
@@ -13,6 +13,7 @@ pub struct NewBuild {
     pub app_id: Option<String>,
     pub public_download: bool,
     pub build_log_url: Option<String>,
+    pub builder_id: Option<String>,
 }
 
 #[derive(Identifiable, Serialize, Queryable, Debug, Eq, PartialEq)]
@@ -34,6 +35,8 @@ pub struct Build {
     pub app_id: Option<String>,
     pub public_download: bool,
     pub build_log_url: Option<String>,
+    /// The builder_id of the token used to create this build
+    pub builder_id: Option<String>,
 }
 
 #[derive(Deserialize, Debug, Eq, PartialEq)]

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -25,6 +25,7 @@ diesel::table! {
         app_id -> Nullable<Text>,
         public_download -> Bool,
         build_log_url -> Nullable<Text>,
+        builder_id -> Nullable<Text>,
     }
 }
 

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -61,6 +61,8 @@ pub struct Claims {
     pub exp: i64,
     pub jti: Option<String>, // an unique ID for the token, for revocation.
 
+    pub builder_id: Option<String>,
+
     #[serde(default)]
     pub scope: Vec<ClaimsScope>,
     #[serde(default)]


### PR DESCRIPTION
We can set a builder_id on a token, and that ID will be stored on every build created with that token. We'll use this in flat-manager-hooks to insert an appstream tag for apps built by buildbot.