### PR TITLE
flat-manager-client: check for all missing objects

### DIFF
--- a/flat-manager-client
+++ b/flat-manager-client
@@ -719,7 +719,7 @@ async def push_command(session, args):
 
     print("Remote missing %d of those" % (len(missing_metadata_objects)))
 
-    file_objects = local_needed_files(local_repo, missing_metadata_objects)
+    file_objects = local_needed_files(local_repo, metadata_objects)
     print("Has %d file objects for those" % (len(file_objects)))
 
     missing_file_objects = await missing_objects(session, args.build_url, token, list(file_objects))


### PR DESCRIPTION
Previously, the code assumed that if a metadata object is available on the server all file objects it points to are also available, which is a reasonable assumption in general.

However, a misbehaving prune operation can leave a repository in such a state with missing file objects.

This change allows the repository to recover by uploading such missing files if they are needed for the currently uploaded commits.