### PR TITLE
Include raw body in ApiError messages

### DIFF
--- a/flat-manager-client
+++ b/flat-manager-client
@@ -58,7 +58,11 @@ class ApiError(Exception):
         try:
             self.body = json.loads(body)
         except (json.JSONDecodeError, TypeError):
-            self.body = {"status": self.status, "error-type": "no-error", "message": "No json error details from server"}
+            self.body = {
+                "status": self.status,
+                "error-type": "no-error",
+                "message": f"Non-json error from server: {body}",
+            }
 
     def repr(self):
         return {

--- a/flat-manager-client
+++ b/flat-manager-client
@@ -57,7 +57,7 @@ class ApiError(Exception):
 
         try:
             self.body = json.loads(body)
-        except:
+        except (json.JSONDecodeError, TypeError):
             self.body = {"status": self.status, "error-type": "no-error", "message": "No json error details from server"}
 
     def repr(self):
@@ -581,7 +581,7 @@ async def publish_build(session, build_url, wait, token):
                 elif current_state == "validating":
                     print("the build is still being validated or held for review")
                     return {}
-            except:
+            except json.JSONDecodeError:
                 pass
 
         if resp.status != 200:


### PR DESCRIPTION
The non-json response could still prove useful when debugging server errors.

Depends on https://github.com/flatpak/flat-manager/pull/133.