### PR TITLE
Update catatonit in Dockerfile to v0.2.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update && apt-get install -y flatpak ostree libpq5 ca-certificates &
 
 RUN ln -s /usr/bin/gpg /usr/bin/gpg2
 
-ADD https://github.com/openSUSE/catatonit/releases/download/v0.1.7/catatonit.x86_64 /usr/local/bin/catatonit
+ADD https://github.com/openSUSE/catatonit/releases/download/v0.2.1/catatonit.x86_64 /usr/local/bin/catatonit
 RUN chmod +x /usr/local/bin/catatonit
 
 COPY --from=builder /src/target/release/flat-manager /usr/local/bin/flat-manager


### PR DESCRIPTION
catatonit v0.2.1 contains an important fix to running it in a rootless Podman container ([see release notes](https://github.com/openSUSE/catatonit/releases/tag/v0.2.1))